### PR TITLE
Add a hover state for states.

### DIFF
--- a/scss/components/_maps.scss
+++ b/scss/components/_maps.scss
@@ -3,6 +3,9 @@ path.shape {
   &.active {
     fill: $primary-contrast;
   }
+  &:hover {
+    stroke: $secondary-contrast;
+  }
 }
 
 .legend {


### PR DESCRIPTION
Note: For this to look good, we have to bring the hovered state path to
the top using javascript; else parts of the state border may be
obscured.

Question for @noahmanger or @onezerojeremy: should there be a hover state for state maps where the states aren't clickable? Under this patch, state borders are highlighted on hover whether clicking does a thing or not, but we can change easily if that would be clearer to users.