### PR TITLE
Restrict details pane behaviors to associated rows.

### DIFF
--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  tr {
+  tr.js-panel-trigger {
     @include transition(border-left-width, .2s);
     border-left-width: 0;
     background-color: $cream;


### PR DESCRIPTION
As of https://github.com/18F/openFEC-web-app/pull/569, data table rows
that trigger a detail panel are given the "js-panel-trigger" class.
Don't use `cursor: pointer` or other panel-related behaviors for other
data table rows.

[Resolves #57]