### PR TITLE
Fixing lists on cms pages + datatables panel height

### DIFF
--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -33,3 +33,4 @@
 @import "search-results"; //@TODO: Document
 @import "search-controls"; //@TODO: Document
 @import "widgets"; //@TODO: Document
+@import "richtext";

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -3,6 +3,8 @@
 // These are styles specifically for content output by the CMS
 
 .rich-text {  
+  padding-top: 2rem;
+  
   ul {
     margin-bottom: 1rem;
 

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -1,0 +1,29 @@
+// Rich Text styles
+//
+// These are styles specifically for content output by the CMS
+
+.rich-text {  
+  ul {
+    margin-bottom: 1rem;
+
+    li {
+      list-style-type: disc;
+      margin-left: 2rem;
+      padding: 0 0 .5rem 0;
+      margin-bottom: 0;
+
+      // Hack because the editor is putting all text in <p>s
+      p {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  ol {
+    li {
+      list-style-type: decimal;
+      margin: 0;
+      padding-left: 1rem;      
+    }
+  }
+}

--- a/scss/modules/_datatable-panel.scss
+++ b/scss/modules/_datatable-panel.scss
@@ -33,7 +33,7 @@
 }
 
 .panel {
-  padding: 2rem 1rem;
+  padding: 1rem;
 
   @include media($med) {
     padding: 0;
@@ -53,6 +53,14 @@
 .panel-active {
   .dataTables_wrapper {
     height: auto;
+  }
+
+  .panel__overlay {
+    min-height: 70vh;
+  }
+
+  .panel__main {
+    min-height: 100vh;
     overflow: hidden;
   }
 
@@ -60,10 +68,10 @@
     .panel__main {
       width: 50%;
       min-height: 70vh;
+      overflow: visible;
     }  
 
     .dataTables_wrapper {
-      min-height: 70vh;
       overflow: visible;
     }
   }
@@ -129,9 +137,10 @@
   @include clearfix();
   border-bottom: 1px solid $ivory;
   text-align: right;
-  padding: .6rem 2rem .6rem 2rem;
+  padding: 0;
 
   @include media($med) {
+    padding: .6rem 2rem .6rem 2rem;
     text-align: left;
   }
 }

--- a/scss/modules/_datatable-panel.scss
+++ b/scss/modules/_datatable-panel.scss
@@ -10,7 +10,6 @@
   top: 0;
   width: 100%;
   background-color: $cream;
-  border-top: 2px solid $primary;
   overflow: hidden;
 
   &[aria-hidden="false"] {
@@ -45,7 +44,6 @@
   clear: both;
 
   @include media($med) {
-    min-height: 70vh;
     height: 100%;
     width: 100%;
   }
@@ -61,6 +59,7 @@
   @include media($med) {
     .panel__main {
       width: 50%;
+      min-height: 70vh;
     }  
 
     .dataTables_wrapper {

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -116,6 +116,10 @@
   &:last-child {
     padding-right: 0;
   }
+
+  a {
+    border: none;
+  }
 }
 
 .site-title {


### PR DESCRIPTION
Sorry, one thing lead to another, so this PR includes two very different things:
1. Adds basic list styling to content blocks from the CMS
2. Fixes height issues with the datatable panels

Resolves https://github.com/18F/openFEC-web-app/issues/638