### PR TITLE
fixing glossary position

### DIFF
--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -158,6 +158,7 @@
 .data-table--wrapped {
   td {
     white-space: pre-wrap;
+    text-overflow: ellipsis;
     overflow: visible;
   }
 }

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -11,7 +11,7 @@
   overflow-y: scroll;
   padding: 2rem;
   position: fixed;
-  top: 7rem;
+  top: 0;
   width: 75%;
   z-index: $z-glossary;
   
@@ -29,15 +29,6 @@
     position: absolute;
     right: 0;
     top: 0;
-  }
-
-  @include media($med) {
-    top: 17rem;
-    width: 50%;
-  }
-
-  @include media($lg) {
-    top: 19rem;
   }
 }
 


### PR DESCRIPTION
Resolves #91 by fixing the glossary to the top of the page, rather than the bottom of the header.