### PR TITLE
Adding simple table styles for cms pages

### DIFF
--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -33,5 +33,6 @@
 @import "search-results"; //@TODO: Document
 @import "search-controls"; //@TODO: Document
 @import "widgets"; //@TODO: Document
+@import "table-styles";  //@TODO: Document
 @import "richtext";
 @import "tooltips";

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -28,4 +28,20 @@
       padding-left: 1rem;      
     }
   }
+
+  table {
+    @extend .simple-table;
+  }
+
+  thead {
+    @extend .simple-table__header;
+  }
+
+  tr {
+    @extend .simple-table__row;
+  }
+
+  td {
+    @extend .simple-table__cell;
+  }
 }

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -6,7 +6,7 @@
   border-width: 2px 0;
   color: $primary;
   font-family: $sans-serif;
-  margin: 0 0 2rem 0;
+  margin: 2rem 0;
 }
 
 .simple-table__header {

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -1,12 +1,20 @@
 // Table styles
 
 .simple-table {
+  border-color: $primary;
+  border-style: solid;
+  border-width: 2px 0;
   color: $primary;
-  margin: 2rem 0;
+  font-family: $sans-serif;
+  margin: 0 0 2rem 0;
 }
 
 .simple-table__header {
   border-bottom: 1px solid $primary;
+
+  th {
+    padding: .5rem 0;
+  }
 }
 
 .simple-table__cell {
@@ -25,4 +33,11 @@
       border-bottom: none;
     }
   }
+}
+
+// Table titles in content are h3, but those have bottom margins.
+// This closes that gap
+
+h3 + .simple-table { 
+  margin-top: -1rem; 
 }

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -1,0 +1,28 @@
+// Table styles
+
+.simple-table {
+  color: $primary;
+  margin: 2rem 0;
+}
+
+.simple-table__header {
+  border-bottom: 1px solid $primary;
+}
+
+.simple-table__cell {
+  padding: 1rem 0;
+  border-bottom: 1px solid $neutral;
+  vertical-align: top;
+
+  &:only-child {
+    border-bottom: none;
+  }
+}
+
+.simple-table__row {
+  &:last-of-type {
+    .simple-table__cell {
+      border-bottom: none;
+    }
+  }
+}


### PR DESCRIPTION
Makes it so that basic tables in CMS content areas look like so:

![screen shot 2015-09-23 at 11 45 58 am](https://cloud.githubusercontent.com/assets/1696495/10055062/134af2dc-61e9-11e5-8b5d-e2ba3101258e.png)

@jenniferthibault any design feedback?