### PR TITLE
More accessibility

### DIFF
--- a/js/accessibility.js
+++ b/js/accessibility.js
@@ -19,9 +19,9 @@ var restoreTabindex = function($elm) {
   $elm.find('a, button, :input, [tabindex]').each(function(){
     $(this).attr('tabindex', '0');
   })
-}
+};
 
 module.exports = {
-  removeTabindex: removeTabindex;
-  restoreTabindex: restoreTabindex;
+  removeTabindex: removeTabindex,
+  restoreTabindex: restoreTabindex
 }

--- a/js/accessibility.js
+++ b/js/accessibility.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/* global require, module, document */
+
+var $ = require('jquery');
+
+/* Utilities for setting or removing tabindex on all focusable elements 
+ * in a parent div. Useful for hiding elements off-canvas without setting 
+ * display:none, while still removing from the tab order
+ */
+
+var removeTabindex = function($elm) {
+  $elm.find('a, button, :input, [tabindex]').each(function(){
+    $(this).attr('tabindex', '-1');
+  })
+};
+
+var restoreTabindex = function($elm) {
+  $elm.find('a, button, :input, [tabindex]').each(function(){
+    $(this).attr('tabindex', '0');
+  })
+}
+
+module.exports = {
+  removeTabindex: removeTabindex;
+  restoreTabindex: restoreTabindex;
+}

--- a/js/accordion.js
+++ b/js/accordion.js
@@ -37,7 +37,8 @@ var accordion = {
     this.$items = this.findItems($base);
     this.$buttons = this.findButtons(this.$headers);
     this.$text = this.findText(this.$headers);
-
+    this.hideText = this.$text.data('hide');
+    this.showText = this.$text.data('show');
     this.hideAll();
 
     this.$buttons.on('click', $.proxy(self.itemClickHandler, this));
@@ -104,7 +105,7 @@ var accordion = {
     $el.attr('aria-hidden', true);
     this.$buttons.attr('aria-expanded', false);
     $el[0].style.display = 'none';
-    this.$text.html('Expand');
+    this.$text.html(this.showText);
   },
   /**
    * Show an element visually.
@@ -116,7 +117,7 @@ var accordion = {
     $el.attr('aria-hidden', false);
     this.$buttons.attr('aria-expanded', true);
     $el[0].style.display = 'block';
-    this.$text.html('Show');
+    this.$text.html(this.hideText);
   },
   /**
    * Hide all items for the current accordion.

--- a/js/accordion.js
+++ b/js/accordion.js
@@ -37,8 +37,8 @@ var accordion = {
     this.$items = this.findItems($base);
     this.$buttons = this.findButtons(this.$headers);
     this.$text = this.findText(this.$headers);
-    this.hideText = this.$text.data('hide');
-    this.showText = this.$text.data('show');
+    this.hideText = this.$text.data('hide') || "Hide";
+    this.showText = this.$text.data('show') || "Show";
     this.hideAll();
 
     this.$buttons.on('click', $.proxy(self.itemClickHandler, this));

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -13,7 +13,7 @@ var ITEM_TEMPLATE =
     '<div class="js-accordion_header accordion__header">' +
       '<h4 class="glossary-term"></h4>' +
       '<button class="button button--secondary accordion__button js-accordion_button">' +
-        '<span class="u-accordion_text u-visually-hidden" data-show="Show definition" data-hide="Hide definition"></span>' +
+        '<span class="js-accordion_text u-visually-hidden" data-show="Show definition" data-hide="Hide definition"></span>' +
       '</button>' +
     '</div>' +
     '<p class="glossary-definition js-accordion_item"></p>' +

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -5,6 +5,7 @@
 var $ = require('jquery');
 var _ = require('underscore');
 var List = require('list.js');
+var accessibility = require('accessibility');
 
 var KEYCODE_ESC = 27;
 
@@ -116,6 +117,7 @@ Glossary.prototype.show = function() {
   this.$toggle.addClass('active');
   this.$search.focus();
   this.isOpen = true;
+  accessibility.restoreTabindex(this.$body);
 };
 
 Glossary.prototype.hide = function() {
@@ -123,6 +125,7 @@ Glossary.prototype.hide = function() {
   this.$toggle.removeClass('active');
   this.$toggle.focus();
   this.isOpen = false;
+  accessibility.removeTabindex(this.$body);
 };
 
 /** Remove existing filters on input */

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -5,7 +5,7 @@
 var $ = require('jquery');
 var _ = require('underscore');
 var List = require('list.js');
-var accessibility = require('accessibility');
+var accessibility = require('./accessibility');
 
 var KEYCODE_ESC = 27;
 

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -13,7 +13,7 @@ var ITEM_TEMPLATE =
     '<div class="js-accordion_header accordion__header">' +
       '<h4 class="glossary-term"></h4>' +
       '<button class="button button--secondary accordion__button js-accordion_button">' +
-        '<span class="u-accordion_text u-visually-hidden">Expand</span>' +
+        '<span class="u-accordion_text u-visually-hidden" data-show="Show definition" data-hide="Hide definition"></span>' +
       '</button>' +
     '</div>' +
     '<p class="glossary-definition js-accordion_item"></p>' +

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -49,6 +49,9 @@ function Glossary(terms, selectors) {
   self.populate();
   self.linkTerms();
 
+  // Remove tabindices 
+  accessibility.removeTabindex(self.$body);
+  
   // Bind listeners
   self.$toggle.on('click', this.toggle.bind(this));
   self.$body.on('click', '.toggle', this.toggle.bind(this));

--- a/js/skip-nav.js
+++ b/js/skip-nav.js
@@ -14,16 +14,19 @@ var $ = require('jquery');
 function Skipnav(anchor, targetBody) {
   this.anchor = anchor;
   this.$targetBody = $(targetBody);
-  this.$target = this.findTarget();
+  this.$target = $(this.findTarget());
   $(document.body).on('click keyup', this.anchor, this.focusOnTarget.bind(this));
 }
 
 Skipnav.prototype.findTarget = function() {
-  return this.$targetBody.find('a, button, :input, [tabindex]').filter(':visible')[0];
+  return this.$targetBody.find(':first-child')
+    .not('div, header, section, article, aside')
+    .filter(':visible')[0];
 };
 
 Skipnav.prototype.focusOnTarget = function(e) {
   if (e.keyCode === 13 || e.type === 'click') {
+    this.$target.attr('tabindex','0');
     this.$target.focus();
   }
 };

--- a/js/skip-nav.js
+++ b/js/skip-nav.js
@@ -25,6 +25,8 @@ Skipnav.prototype.findTarget = function() {
 };
 
 Skipnav.prototype.focusOnTarget = function(e) {
+  e.preventDefault();
+  
   if (e.keyCode === 13 || e.type === 'click') {
     this.$target.attr('tabindex','0');
     this.$target.focus();

--- a/js/terms.json
+++ b/js/terms.json
@@ -84,7 +84,7 @@
     "glossary-definition": "An electioneering communication is any broadcast, cable or satellite communication that fulfills <em>each</em> of the following conditions:<ul class='default-ul'><li>The communication refers to a clearly identified candidate for federal office;</li><li>The communication is publicly distributed shortly before an election for the office that candidate is seeking; and</li><li>The communication is targeted to the relevant electorate (U.S. House and Senate candidates only).</li></ul>"
    },
    {
-    "glossary-definition": "Communication cost",
-    "glossary-term": "52 U.S.C. 30118 allows \"communications by a corporation to its stockholders and executive or administrative personnel and their families or by a labor organization to its members and their families on any subject,\" including the express advocacy of the election or defeat of any Federal candidate. The costs of such communications must be reported to the Federal Election Commission under certain circumstances."
+    "glossary-term": "Communication cost",
+    "glossary-definition": "52 U.S.C. 30118 allows \"communications by a corporation to its stockholders and executive or administrative personnel and their families or by a labor organization to its members and their families on any subject,\" including the express advocacy of the election or defeat of any Federal candidate. The costs of such communications must be reported to the Federal Election Commission under certain circumstances."
    }
 ]

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -53,10 +53,6 @@
     background-color: lighten($primary-contrast, 10%);
   }
 
-  &:focus {
-    border: 2px solid $primary-focus;
-  }
-
   &:active,
   &.is-active {
     background-color: $navy;
@@ -85,10 +81,6 @@
     background-color: lighten($secondary-contrast, 10%);
   }
 
-  &:focus {
-    border-color: $secondary-focus;
-  }
-
   &:active,
   &.is-active {
     background-color: $deep-red;
@@ -115,10 +107,6 @@
 
   &:hover {
     background-color: $brown-light;
-  }
-
-  &:focus {
-    border-color: $neutral-focus;
   }
 
   &:active,
@@ -197,10 +185,6 @@
 
   &:hover {
     background-color: lighten($primary, 10%);
-  }
-
-  &:focus {
-    border-color: $primary-focus;
   }
 
   &:active,

--- a/scss/components/_callouts.scss
+++ b/scss/components/_callouts.scss
@@ -41,10 +41,6 @@
   @include span-columns(1 of 3);
   padding: 1rem;
   border-bottom: none;
-
-  &:focus {
-    outline: 2px solid;
-  }
 }
 
 .callout__sublinks {

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -39,12 +39,6 @@
   &:hover {
     border-bottom: none;
   }
-
-  &:focus {
-    img {
-      outline: 2px solid;
-    }
-  }
 }
 
 .card__content {

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -167,6 +167,8 @@
     .icon--complex {
       max-height: 10rem;
       max-width: 10rem;
+      display: inline;
+      float: none;
     }    
   }
 }

--- a/scss/elements/_forms.scss
+++ b/scss/elements/_forms.scss
@@ -58,7 +58,6 @@ select {
   width: 100%;
 
   &:focus {
-    outline: none;
     border-color: $primary;
     color: $primary;
   }

--- a/scss/elements/_links.scss
+++ b/scss/elements/_links.scss
@@ -15,13 +15,11 @@ a {
   transition: color 0.1s linear;
 
   &:active,
-  &:focus,
   &:hover {
     border-bottom-color: $primary-contrast;
   }
 
   img {
-    outline: none;
     border: none;
   }
 }

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -86,19 +86,11 @@
   .button--primary {
     color: $primary;
     border-color: transparent;
-
-    &:focus {
-      border-color: $primary-focus;
-    }
   }
   
   .button--secondary {
     color: $secondary;
-    border-color: transparent;
-    
-    &:focus {
-      border-color: $secondary-focus;
-    }    
+    border-color: transparent;  
   }
 
   .button:hover {
@@ -126,10 +118,6 @@
     color: $contrast-color;
     border-color: $contrast-color;
     background-color: $background-color;
-
-    &:focus {
-      border-color: $focus-color;
-    }
   }
 
   #{$all-text-inputs} {
@@ -182,8 +170,7 @@
   a {
     border-bottom-color: $ivory;
     
-    &:hover,
-    &:focus {
+    &:hover {
       border-bottom-color: $primary-contrast;
     }
   }
@@ -207,8 +194,7 @@
   a {
     border-bottom-color: $ivory;
 
-    &:hover,
-    &:focus {
+    &:hover {
       border-bottom-color: $secondary-contrast;
     }
   } 
@@ -224,8 +210,7 @@
   background-color: $ivory;
   
   a {
-    &:hover,
-    &:focus {
+    &:hover {
       border-bottom-color: $primary-contrast;
     }
   } 

--- a/scss/modules/_datatable-panel.scss
+++ b/scss/modules/_datatable-panel.scss
@@ -27,7 +27,6 @@
 .panel__overlay {
   @include transition(opacity .2s);
   background-color: $cream;
-  display: block !important; // Overriding default [aria-hidden=true] styling
   overflow: hidden;
   padding: 1rem;
   position: absolute;

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -67,11 +67,6 @@
   height: 4rem;
   padding: 1rem 1rem 1rem 3rem;
 
-  &:focus {
-    outline: none;
-    border-color: $primary;
-  }
-
   @include media($lg) {
     @include transform(translateX(0));
     @include transition(width, .1s);

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -53,6 +53,7 @@
 
   .accordion__button {
     background-size: 50%;
+    margin-top: -1rem;
     height: 2rem;
     width: 2rem;
   }

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -78,7 +78,6 @@
   &:focus,
   &:hover {
     @include u-background-image('i-term--secondary', 100% 40%);
-    outline: none;
     box-shadow: 0 0 0 4px rgba($secondary-contrast, .7);
     background-color: rgba($secondary-contrast, .7);
     color: $secondary;

--- a/scss/modules/_nav.scss
+++ b/scss/modules/_nav.scss
@@ -147,7 +147,6 @@
     &:active {
       border-bottom-color: transparent;
       background-color: $ivory;
-      outline: 2px;
     }
   }
 }

--- a/scss/modules/_page-controls.scss
+++ b/scss/modules/_page-controls.scss
@@ -82,10 +82,6 @@
     &[aria-selected="true"] {
       background-color: $cream;
     }
-
-    &:focus {
-      box-shadow: inset 0 0 0px 3px $primary-contrast;
-    }
   }
 }
 

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -119,10 +119,6 @@
 
   a {
     border: none;
-
-    &:focus {
-      outline: 2px solid $primary;
-    }
   }
 }
 
@@ -131,10 +127,6 @@
   border-bottom: 0;
   display: block;
   float: left;
-
-  &:focus {
-    outline: 2px solid $primary;
-  }
 }
 
 // Mobile site title is included in the .site-nav nav element


### PR DESCRIPTION
- Removes :focus style overrides to use the native browser focus effects (resolves #25 )
- Adds a simple accessibility helper file that currently includes functions to remove / re-add `tabindex` to child elements of a div that's hidden off-screen (necessary, becuase in order to have the slide-in effect, we can't use `display: none` -- but if an item is still displayed but hidden, it remains in the tab order)
- Updates the accordion and glossary components to adjust the text of the toggle buttons
- Makes a couple minor style tweeks
- Improves the skip-nav component to find the first non-`div`-type element and focus on that, instead of only form fields. This way, screenreaders won't skip over necessary content.