### PR TITLE
Search bar styling

### DIFF
--- a/scss/components/_page-headers.scss
+++ b/scss/components/_page-headers.scss
@@ -49,7 +49,7 @@
 
 @include media($med) {
   .page-header {
-    padding: 1rem 4rem;
+    padding: 1rem 2rem;
 
     .search__container {
       display: block;

--- a/scss/components/_page-headers.scss
+++ b/scss/components/_page-headers.scss
@@ -56,7 +56,7 @@
     .search__container {
       display: block;
       float: right;
-      width: 50%;
+      width: 40rem;
     }  
   }
 
@@ -64,7 +64,17 @@
     @include media($med) {
     float: left;
     line-height: 4rem;
-    width: calc(50% - 4rem);
   }
+  }
+}
+
+// BREAKPOINT: Large
+// Wider search bar
+
+@include media($lg) {
+  .page-header {
+    .search__container {
+      width: 50rem;
+    }
   }
 }

--- a/scss/components/_page-headers.scss
+++ b/scss/components/_page-headers.scss
@@ -28,7 +28,9 @@
   border-bottom: none;
   font-family: $sans-serif;
   font-size: 1.6rem;
+  text-transform: uppercase;
   margin-bottom: 0;
+  margin-left: 2rem;
   line-height: 1;
 }
 

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -42,11 +42,11 @@
 @include media($med) {
   .combo--search {
     .combo__input {
-      width: calc(100% - 21.6rem);
+      width: calc(100% - 20.6rem);
     }
 
     .combo__button {
-      width: 6.6rem; 
+      width: 5.6rem; 
     }
   }
   

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -30,12 +30,11 @@
   float: left;
 }
 
-.combo__select {
-  width: 14rem;
-}
-
-.combo__input {
-  width: calc(100% - 14rem)
+.combo--search {
+  .combo__input {
+    border-radius: 0 4px 4px 0;
+    width: calc(100% - 14rem)
+  }
 }
 
 // BREAKPOINT: MEDIUM

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -26,27 +26,27 @@
   border-radius: 4px 0 0 4px;
   margin-right: -2px;
   height: 3.6rem;
-  width: 12rem;
+  width: 14rem;
   float: left;
 }
 
 .combo__select {
-  width: 12rem;
+  width: 14rem;
 }
 
 .combo__input {
-  width: calc(100% - 12rem)
+  width: calc(100% - 14rem)
 }
 
 // BREAKPOINT: MEDIUM
 @include media($med) {
   .combo--search {
     .combo__input {
-      width: calc(100% - 16.6rem);
+      width: calc(100% - 21.6rem);
     }
 
     .combo__button {
-      width: 3.6rem; 
+      width: 6.6rem; 
     }
   }
   
@@ -69,7 +69,6 @@
       height: 6rem;
       width: 16rem;
       font-size: 1.8rem;
-      
     }
 
     .tt-dropdown-menu {

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -41,6 +41,7 @@
 @include media($med) {
   .combo--search {
     .combo__input {
+      border-radius: 0 0 0 0;
       width: calc(100% - 20.6rem);
     }
 


### PR DESCRIPTION
This resolves https://github.com/18F/openFEC/issues/1222 by:
 - Making the drop-down field wider
 - Makes the search button slightly wider, and aligns it with the grid lines created by the glossary button above it.

Review:
@noahmanger 

I'm not sure if `.combo__select` and `.combo__input` needed to be adjusted for this, but it looked like them might need to be.

_______________________________

There is an additional change I'd like to make to the styling here, but I'm not sure how. I'd like to make the search text entry field less wide so that the whole search element is about 75% as wide as it is now. I think it is a bit too wide and becomes distracting because it doesn't align with other grid elements.

Here is current:
<img width="1234" alt="screen shot 2015-09-26 at 1 13 27 pm" src="https://cloud.githubusercontent.com/assets/11636908/10118829/0a3fcf54-6451-11e5-8edd-496886293cab.png">
Ideally the search bar would start on the left side right about where the last (Page TBD) begins, and ends where it currently ends as shown above. Like this:
![screen shot 2015-09-26 at 1 21 14 pm](https://cloud.githubusercontent.com/assets/11636908/10118840/7f032a16-6451-11e5-9e0b-4ed979d640df.png)
 