### PR TITLE
making link underline narrower

### DIFF
--- a/scss/elements/_links.scss
+++ b/scss/elements/_links.scss
@@ -8,7 +8,7 @@
 // Styleguide elements.links
 
 a {
-  border-bottom: 2px dotted $primary;
+  border-bottom: 1px dotted $primary;
   color: $primary;
   cursor: pointer;
   text-decoration: none;


### PR DESCRIPTION
A small change that makes the link underline style narrower, and less distracting in situations with many links in a row.