### PR TITLE
Dropdown improvement

### DIFF
--- a/js/dropdowns.js
+++ b/js/dropdowns.js
@@ -66,7 +66,7 @@ Dropdown.prototype.handleClickAway = function(e) {
 
 Dropdown.prototype.handleFocusAway = function(e) {
   var $target = $(e.target);
-  if (this.isOpen && !this.$panel.has($target).length) {
+  if (this.isOpen && !this.$panel.has($target).length && !$target.is(this.$button)) {
     this.hide();
   }
 };


### PR DESCRIPTION
Previously, if you opened the dropdown and then clicked on the button again, it would stay open. This patch fixes that so now why you click on the button again it closes (and it still closes if you focus away from the dropdown or click somewhere else on the page).