### PR TITLE
Consistent double quotes

### DIFF
--- a/js/terms.json
+++ b/js/terms.json
@@ -9,7 +9,7 @@
   },
   {
     "glossary-term": "Party",
-    "glossary-definition": "Party affiliation as stated on a candidate’s 'Statement of Candidacy.'"
+    "glossary-definition": "Party affiliation as stated on a candidate’s \"Statement of Candidacy.\""
   },
   {
     "glossary-term": "District",
@@ -97,6 +97,6 @@
   },
   {
     "glossary-term": "Separate Segregated Fund (SSF)",
-    "glossary-definition": "A political committee established, administered or financially supported by a corporation or labor organization, popularly called a corporate or labor political action committee or PAC. 11 CFR 114.1(a)(2)(iii). The term 'financially supported' does not include contributions to the SSF but does include the payment of establishment, administration or solicitation costs. 11 CFR 100.6(b)."
+    "glossary-definition": "A political committee established, administered or financially supported by a corporation or labor organization, popularly called a corporate or labor political action committee or PAC. 11 CFR 114.1(a)(2)(iii). The term \"financially supported\" does not include contributions to the SSF but does include the payment of establishment, administration or solicitation costs. 11 CFR 100.6(b)."
   }
 ]


### PR DESCRIPTION
Makes all quotes double;
eliminates single quotes
in definitions.

Resolves #144