### PR TITLE
Removes terms

### DIFF
--- a/js/terms.json
+++ b/js/terms.json
@@ -78,25 +78,5 @@
   {
     "glossary-term": "Independent expenditure",
     "glossary-definition": "An expenditure for a communication that expressly advocates the election or defeat of a clearly identified candidate and that is not made in cooperation, consultation or concert with, or at the request or suggestion of, any candidate, or his or her authorized committees or agents, or a political party committee or its agents. 11 CFR 100.16."
-  },
-  {
-    "glossary-term": "Electioneering communication",
-    "glossary-definition": "Any broadcast, cable or satellite communication that: <ul><li>Refers to a clearly identified candidate for federal office;</li><li>Is publicly distributed within certain time periods before an election; and</li><li>Is targeted to the relevant electorate.</li></ul>11 CFR 100.29."
-  },
-  {
-    "glossary-term": "Communication cost",
-    "glossary-definition": "52 U.S.C. 30118 allows \"communications by a corporation to its stockholders and executive or administrative personnel and their families or by a labor organization to its members and their families on any subject,\" including the express advocacy of the election or defeat of any federal candidate. The costs of such communications must be reported to the Federal Election Commission under certain circumstances."
-  },
-  {
-    "glossary-term": "Receipt",
-    "glossary-definition": "Anything of value (money, goods, services of property) received by a political committee."
-  },
-  {
-    "glossary-term": "Disbursement",
-    "glossary-definition": "Any purchase or payment made by a political committee or any other person that is subject to FECA. 11 CFR 300.2(d)."
-  },
-  {
-    "glossary-term": "Separate Segregated Fund (SSF)",
-    "glossary-definition": "A political committee established, administered or financially supported by a corporation or labor organization, popularly called a corporate or labor political action committee or PAC. 11 CFR 114.1(a)(2)(iii). The term \"financially supported\" does not include contributions to the SSF but does include the payment of establishment, administration or solicitation costs. 11 CFR 100.6(b)."
   }
 ]


### PR DESCRIPTION
At FEC request, removes `electioneering communication`, `communication cost`, `receipt`, `disbursement`, and `separate segregated fund` from glossary terms.

Resolves 18F/openFEC-web-app#840
Resolves 18F/openFEC-web-app#841

[ci skip]