### PR TITLE
Forcing height 0 on invisible twitter-typeahead div

### DIFF
--- a/scss/components/_form-styles.scss
+++ b/scss/components/_form-styles.scss
@@ -48,12 +48,12 @@
 
   .combo__input {
     height: 3.6rem;
-    margin-bottom: 1rem;
   }
 
   .combo__button {
-    width: 100%;
     height: 3.6rem;
+    margin-top: 1rem;
+    width: 100%;
   }
 
   @include media($med) {
@@ -61,13 +61,13 @@
       height: 3.6rem;
       border-radius: 2px 0 0 2px;
       float: left;
-      margin-bottom: 0;
       width: 80%;
     }
 
     .combo__button {
       border-radius: 0 4px 4px 0;
       float: left;
+      margin-top: 0;
       width: 20%;
     }
   }

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -46,13 +46,13 @@
     }
 
     .combo__button {
-      width: 5.6rem; 
+      width: 5.6rem;
     }
   }
-  
+
   .combo--search--large {
     height: 6rem;
-    
+
     .combo__input {
       font-size: 1.8rem;
       height: 6rem;
@@ -80,6 +80,7 @@
 
 // Typeahead styles
 .twitter-typeahead {
+  height: 0;
   width: 100%;
 }
 
@@ -91,7 +92,7 @@
   text-align: left;
   position: absolute;
   width: 100%;
-  
+
   @include media($med) {
     width: calc(100% - 6.8rem);
   }
@@ -131,7 +132,7 @@ span.tt-suggestion__office {
 .tt-cursor {
   cursor: pointer;
   background: $ivory;
-  
+
   .tt-suggestion__name {
     color: $primary;
   }


### PR DESCRIPTION
For some reason, it only had a height on mobile, which mean that it overlapped the search select box, making it unusable. This sets the height to 0, and also adds margin to the top of the search button at mobile, rather than the bottom of the input.

Resolves https://github.com/18F/openFEC-web-app/issues/542