### PR TITLE
Adding gutter between map and left half of election header

### DIFF
--- a/scss/modules/_entity-header.scss
+++ b/scss/modules/_entity-header.scss
@@ -23,12 +23,12 @@
       color: $primary;
     }
   }
-  
+
   @include media($med) {
     height: 30rem;
-    
+
     .entity__header--info {
-      width: 50%;
+      @include span-columns(6);
     }
 
     .map {
@@ -37,7 +37,7 @@
       height: 34rem;
       top: 0;
       bottom: 0;
-      right: 0; 
+      right: 0;
     }
   }
 }
@@ -59,7 +59,7 @@
 
 
 .entity__info {
-  @include clearfix(); 
+  @include clearfix();
   font-family: $sans-serif;
   padding-top: 1rem;
   width: 100%;
@@ -80,7 +80,7 @@
   &:last-child {
     margin-bottom: 0;
   }
-  
+
   @include media($med) {
     display: table-cell;
     width: auto;


### PR DESCRIPTION
Adds gutter between the left half of the election page header and the map on the right:

<img width="1353" alt="screen shot 2015-10-20 at 11 41 07 am" src="https://cloud.githubusercontent.com/assets/1696495/10617453/85a72968-771f-11e5-80d6-62dc7dceec4b.png">
