### PR TITLE
Rare color hunting

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -23,9 +23,9 @@ $deep-aqua: #3e8a9a;
 $navy: #164f85;
 
 $beige: #ceb59c;
+$beige-light: #d8c4b1;
 $brown: #c09c7c;
 $black: #000205;
-$brown-light: #d8c4b1;
 $brown-dark: #c09c7c;
 
 // Color aliases

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -10,7 +10,7 @@ $orange: #f77b42;
 $federal-blue: #022c53;
 $aqua: #36bdbb;
 
-$ivory: #f7eee3;
+$ivory: #F5F0E4;
 $cream: #ffffff;
 $ivory-dark: #d8c4b1;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -24,9 +24,8 @@ $navy: #164f85;
 
 $beige: #ceb59c;
 $beige-light: #d8c4b1;
-$brown: #c09c7c;
+$beige-dark: #c09c7c;
 $black: #000205;
-$brown-dark: #c09c7c;
 
 // Color aliases
 $primary: $federal-blue;
@@ -38,7 +37,7 @@ $secondary-contrast: $orange;
 $secondary-focus: $deep-red;
 
 $neutral: $ivory;
-$neutral-contrast: $brown;
+$neutral-contrast: $beige-dark;
 $neutral-focus: $primary;
 
 // Z-Indices

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -12,7 +12,6 @@ $aqua: #36bdbb;
 
 $ivory: #F5F0E4;
 $cream: #ffffff;
-$ivory-dark: #d8c4b1;
 
 // Accent colors
 $bright-red: #dd1400;

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -111,7 +111,7 @@
 
   &:active,
   &.is-active {
-    background-color: $brown;
+    background-color: $beige-dark;
     border: 2px solid $primary;
   }
 }

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -106,7 +106,7 @@
   color: $primary;
 
   &:hover {
-    background-color: $brown-light;
+    background-color: $beige-light;
   }
 
   &:active,

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -64,13 +64,13 @@
   top: 3.2rem;
   min-width: 100%;
   background: $cream;
-  border: 2px solid $ivory-dark;
+  border: 2px solid $beige;
   max-height: 30rem;
   overflow: hidden;
   z-index: 999;
 
   .dropdown__value {
-    border-bottom: 2px solid $ivory-dark;
+    border-bottom: 2px solid $beige;
     margin-bottom: 0;
     padding: .5rem 1rem;
     white-space: nowrap;
@@ -132,11 +132,11 @@
   position: absolute;
   background: $ivory;
   width: 4px;
-  border-left: 1px solid $ivory-dark;
+  border-left: 1px solid $beige;
 }
 
 .ps-scrollbar-y {
   position: absolute;
   width: 4px;
-  background: $ivory-dark;
+  background: $beige;
 }

--- a/scss/components/_messages.scss
+++ b/scss/components/_messages.scss
@@ -18,7 +18,7 @@
 .message {
   @include clearfix();
   background-size: 2rem;
-  background-color: rgba($ivory-dark, .5);
+  background-color: $ivory;
   border-color: $beige;
   border-top: 2px solid $beige;
   padding: 5rem 2rem 2rem 2rem;

--- a/scss/components/_toggles.scss
+++ b/scss/components/_toggles.scss
@@ -46,7 +46,7 @@
     }
 
     & + .button--neutral {
-      background-color: $brown;
+      background-color: $beige-dark;
       border: 2px solid $primary;
     }
 

--- a/scss/elements/_forms.scss
+++ b/scss/elements/_forms.scss
@@ -44,7 +44,7 @@ select[multiple=multiple],
 textarea,
 select {
   background-color: $cream;
-  border-color: $brown;
+  border-color: $beige-dark;
   border-width: 2px;
   border-style: solid;
   border-radius: 4px;


### PR DESCRIPTION

<img width="1023" alt="screen shot 2015-10-23 at 1 59 19 pm" src="https://cloud.githubusercontent.com/assets/11636908/10706251/64703e92-79b3-11e5-8cd3-28262a151586.png">


### Changes
I noticed on pages like this that we had many variances of beige/brown. This PR eliminates the color category “brown” and replaces all instances of it with “beige” “light-beige” or “dark-beige” which were duplicates of the same hex code anyways.

Now it should look like this:
<img width="1013" alt="screen shot 2015-10-23 at 6 27 31 pm" src="https://cloud.githubusercontent.com/assets/11636908/10706307/d29757ca-79b3-11e5-8944-0f1b55ed057d.png">

This change also simplifies drop-downs, buttons, and hover states :+1: 

### Review
@noahmanger 