### PR TITLE
Fix and expand glossary tests.

### DIFF
--- a/js/glossary.js
+++ b/js/glossary.js
@@ -41,6 +41,7 @@ function Glossary(terms, selectors) {
   self.$body = $(self.selectors.body);
   self.$toggle = $(self.selectors.toggle);
   self.$search = this.$body.find('.glossary__search');
+  self.$trigger = null;
 
   // Initialize state
   self.isOpen = false;
@@ -127,13 +128,13 @@ Glossary.prototype.show = function(e) {
 Glossary.prototype.hide = function() {
   this.$body.removeClass('is-open').attr('aria-hidden', 'true');
   this.$toggle.removeClass('active');
-  this.$trigger.focus();
+  this.$trigger && this.$trigger.focus();
   this.isOpen = false;
   accessibility.removeTabindex(this.$body);
 };
 
 /** Remove existing filters on input */
-Glossary.prototype.handleInput = function(e) {
+Glossary.prototype.handleInput = function() {
   if (this.list.filtered) {
     this.list.filter();
   }

--- a/tests/glossary.js
+++ b/tests/glossary.js
@@ -48,7 +48,7 @@ describe('glossary', function() {
   });
 
   it('shows', function() {
-    this.glossary.show();
+    this.glossary.show({target: this.glossary.$toggle});
     expect(isOpen(this.glossary)).to.be.true;
   });
 
@@ -58,10 +58,12 @@ describe('glossary', function() {
   });
 
   it('toggles', function() {
-    this.glossary.toggle();
+    this.glossary.toggle({target: this.glossary.$toggle});
     expect(isOpen(this.glossary)).to.be.true;
+    expect(this.glossary.$trigger.is(this.glossary.$toggle)).to.be.true;
     this.glossary.toggle();
     expect(isClosed(this.glossary)).to.be.true;
+    expect(this.glossary.$toggle.is(document.activeElement)).to.be.true;
   });
 
   it('linkifies terms in the document', function() {


### PR DESCRIPTION
* Pass mock events to glossary methods as needed
* Test that hiding the glossary focuses the trigger
* Short-circuit focus if trigger is not set

cc @noahmanger