### PR TITLE
Adds text to the empty element

### DIFF
--- a/js/templates/feedback.html
+++ b/js/templates/feedback.html
@@ -4,7 +4,7 @@
     <button class="js-feedback button--down feedback__close"><span class="u-visually-hidden">Close</span></button>
     <div class="js-status message message--primary" aria-hidden="true">
       <div class="js-status-content"></div>
-      <button class="js-reset button--primary feedback__button" type="button"></button>
+      <button class="js-reset button--primary feedback__button" type="button">Submit another issue</button>
     </div>
     <form id="feedback-form" class="container">
       <fieldset>


### PR DESCRIPTION
As noted in https://github.com/18F/openFEC-web-app/issues/905 , HTML
Code Sniffer was throwing an error because this button was empty, even
though it would be populated with text by the time the user saw it.
This is a minor change to prevent that error from showing up.