### PR TITLE
Skip coverage instrumentation on --debug.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,27 @@
+/* global process */
+
 var istanbul = require('browserify-istanbul');
 
 module.exports = function(config) {
+  var browserify = {
+    debug: true,
+    transform: ['stringify']
+  };
+
+  var reporters = ['progress'];
+
+  if (process.argv.indexOf('--debug') === -1) {
+    browserify.transform.push(
+      istanbul({
+        ignore: [
+          'tests/unit/**/*',
+          '**/templates/**'
+        ]
+      })
+    );
+    reporters.push('coverage');
+  }
+
   config.set({
     frameworks: ['browserify', 'phantomjs-shim', 'mocha', 'chai-sinon'],
 
@@ -14,18 +35,7 @@ module.exports = function(config) {
       'js/**/*.js': ['browserify']
     },
 
-    browserify: {
-      debug: true,
-      transform: [
-        'stringify',
-        istanbul({
-          ignore: [
-            'tests/unit/**',
-            '**/templates/**'
-          ]
-        })
-      ]
-    },
+    browserify: browserify,
 
     coverageReporter: {
       subdir: '.',
@@ -36,7 +46,7 @@ module.exports = function(config) {
       ]
     },
 
-    reporters: ['progress', 'coverage'],
+    reporters: reporters,
     browsers: ['Chrome'],
     port: 9876
   });


### PR DESCRIPTION
Skip coverage instrumentation when running karma with the `--debug` flag for easier in-browser debugging.