### PR TITLE
Version using semver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ When merging into master, update the package version and push to npm:
     npm publish
     git push --tags
 
+Use `npm version minor` or `npm version major` for minor and major updates, respectively. For details on npm versioning, see `npm version --help`.
+
 Downstream applications should pin versions as appropriate. For example, to get bug fixes but not new features, pin to the minor version:
 
     {

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 
 ## Campaign finance for everyone
-The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives. 
+The Federal Election Commission (FEC) releases information to the public about money that’s raised and spent in federal elections — that’s elections for US president, Senate, and House of Representatives.
 
 Are you interested in seeing how much money a candidate raised? Or spent? How much debt they took on? Who contributed to their campaign? The FEC is the authoritative source for that information.
 
-betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users. 
+betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users.
 
-## FEC repositories 
+## FEC repositories
 We welcome you to explore our FEC repositories, make suggestions, and contribute to our code. Our repositories are:
 
 - [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from betaFEC’s feedback widget here, and this is the best place to submit general feedback.
@@ -22,7 +22,7 @@ We welcome you to explore our FEC repositories, make suggestions, and contribute
 We’re thrilled you want to get involved! Here are some suggestions:
 - Check out our [contributing guidelines](https://github.com/18F/openfec/blob/master/CONTRIBUTING.md). Then, [file an issue](https://github.com/18F/fec/issues) or submit a pull request.
 - [Send us an email](mailto:betafeedback@fec.gov).
-- If you’re a developer, follow the installation instructions in the README.md page of each repository to run the apps on your computer. 
+- If you’re a developer, follow the installation instructions in the README.md page of each repository to run the apps on your computer.
 
 ## Copyright and licensing
 This project is in the public domain within the United States, and we waive worldwide copyright and related rights through [CC0 universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). Read more on our license page.
@@ -100,3 +100,28 @@ We use the KSS standard for documenting our Sass. This is both readable to human
 // Styleguide 2.1.3.
 //
 ```
+
+### Versioning
+
+We use [Semantic Versioning](http://semver.org/):
+
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+>
+> MAJOR version when you make incompatible API changes,
+> MINOR version when you add functionality in a backwards-compatible manner, and
+> PATCH version when you make backwards-compatible bug fixes.
+> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+
+When merging into master, update the package version and push to npm:
+
+    npm version patch
+    npm publish
+    git push --tags
+
+Downstream applications should pin versions as appropriate. For example, to get bug fixes but not new features, pin to the minor version:
+
+    {
+        "dependencies": {
+            "fec-style": "~1.0.0"
+        }
+    }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-style",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Shared styles for FEC Beta",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Proposal: Version fec-style using semantic versioning. Bug fixes
increment the patch, non-breaking changes increment the minor version, and
breaking changes increment the major version. To support flexible
version ranges (e.g. ~1.0.0), fec-style should be published to npm. If
we go in this direction, everyone who needs to be able to push changes
will need an npm account with permissions to update the fec-style
package. I'm arbitrarily calling this version 1.0.0.

Thoughts @noahmanger @shawnbot @msecret? I'm also hoping that versioning upstream dependencies gets simpler as we break more components out of fec-style and into their own packages.