### PR TITLE
Styling new cycle-selects

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -87,7 +87,7 @@ linters:
     severity: warning
   SelectorDepth:
     enabled: true
-    max_depth: 2
+    max_depth: 3
     severity: warning
   SelectorFormat:
     enabled: false # strict_BEM doesn't seem to be supported by Hound

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -5,6 +5,7 @@
 //
 // .card--mini            - For use in sidebars
 // .card--horizontal      - Image next to text
+// .card--feature         - Image in a block next to content
 // .card--wide            - Card takes up half of grid
 //
 // Markup:
@@ -27,7 +28,7 @@
   margin-bottom: 2rem;
   padding: 2rem;
   text-align: center;
-  
+
   @include media($med) {
     @include span-columns(2)
   }
@@ -39,6 +40,11 @@
   &:hover {
     border-bottom: none;
   }
+}
+
+.card--full {
+  width: 100%;
+  margin: 0;
 }
 
 .card__content {
@@ -96,6 +102,26 @@
 
   .card__content {
     padding: 0;
+  }
+}
+
+.card--feature {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+
+  .card__image__container {
+    @include span-columns(1 of 4);
+    border-radius: 4px 0 0 4px;
+  }
+
+  .card__image {
+    max-width: 100%;
+  }
+
+  .card__content {
+    @include span-columns(3 of 4);
+    padding: 1rem 1rem 1rem 0;
   }
 }
 
@@ -165,11 +191,11 @@
       max-width: 10rem;
       display: inline;
       float: none;
-    }    
+    }
   }
 }
 
-// For lists of links, such as on data landing page cards 
+// For lists of links, such as on data landing page cards
 .card__links {
   font-family: $sans-serif;
   font-weight: normal;
@@ -225,10 +251,20 @@
   font-weight: bold;
 }
 
+// Neutral cards
+
+.card--neutral {
+  background-color: $beige;
+
+  .card__image__container {
+    background-color: $primary;
+  }
+}
+
 // Tiled cards
-// 
+//
 // For showing multiple rows of cards, use:
-// 
+//
 // .tiled-cards
 //
 // Styleguide components.cards.tiled-cards

--- a/scss/components/_cycle-select.scss
+++ b/scss/components/_cycle-select.scss
@@ -1,19 +1,59 @@
 // Cycle Select
 //
-// Styling for when it's inline with a heading
-//
-// Markup:
-// <h2>Section title
-//   <select class="cycle-select js-cycle" aria-label="Two-Year Period" name="cycle">
-//     <option>2012 - 2013</option>
-//     <option>2012 - 2013</option>
-//     <option>2012 - 2013</option>
-//   </select>
-// </h2>
-//
 // Styleguide components.cycle-select
 
 .cycle-select {
-  display: inline-block;
-  margin-bottom: 1rem;
+  @include span-columns(6);
+
+  select {
+    width: 100%;
+  }
+}
+
+.cycle-select__label {
+  font-family: $sans-serif;
+  font-weight: bold;
+}
+
+.subcycle-select {
+  @include span-columns(6);
+  font-family: $sans-serif;
+
+  .toggles {
+    clear: both;
+
+    .button {
+      padding: .9rem 1rem;
+    }
+  }
+}
+
+.subcycle--all-selected {
+  .button--neutral {
+    background-color: $beige-dark;
+    border: 2px solid $primary;
+  }
+
+  .button--primary {
+    @extend .button--primary.is-active;
+  }
+}
+
+// BREAKPOINT: MEDIUM
+@include media($med) {
+  .cycle-select {
+    @include span-columns(2 of 8);
+  }
+
+  .subcycle-select {
+    @include span-columns(6 of 8);
+  }
+}
+
+// BREAKPOINT: LARGE
+@include media($lg) {
+  .subcycle-select label:first-child {
+    @include span-columns(2 of 8);
+    margin: 0;
+  }
 }

--- a/scss/modules/_entity-header.scss
+++ b/scss/modules/_entity-header.scss
@@ -43,8 +43,11 @@
 }
 
 .entity__header__top {
-  border-bottom: 2px solid;
   padding-bottom: .5rem;
+}
+
+.entity__header__bottom {
+  padding: 2rem 0 0 0;
 }
 
 .entity__name {
@@ -60,15 +63,14 @@
 
 .entity__info {
   @include clearfix();
+  border-bottom: 2px solid;
+  border-top: 2px solid;
   font-family: $sans-serif;
-  padding-top: 1rem;
+  padding: 1rem 0;
   width: 100%;
 
   @include media($med) {
     display: table;
-    max-width: 100%;
-    padding-top: 2rem;
-    width: auto;
   }
 }
 
@@ -103,6 +105,7 @@
 
 .entity__term__label {
   @include span-columns(6);
+  font-family: $sans-serif;
   font-weight: bold;
 
   @include media($med) {
@@ -122,12 +125,21 @@
   }
 }
 
+.entity__election {
+  clear: both;
+  padding-top: 1rem;
+
+  .entity__term__label {
+    width: 100%;
+  }
+}
+
 // Color rules
 
 .entity__header--neutral {
   @include u-bg--neutral();
 
-  .entity__header__top,
+  .entity__info,
   .entity__type  {
     border-color: $primary;
   }
@@ -137,7 +149,7 @@
   @include u-bg--primary();
   border-top: 1px solid $primary-contrast;
 
-  .entity__header__top,
+  .entity__info,
   .entity__type {
     border-color: $primary-contrast;
   }
@@ -151,4 +163,19 @@
     padding-right: 1rem;
     border-right: 1px solid;
   }
+
+  .entity__cycle {
+    @include span-columns(8);
+  }
+
+  .entity__election {
+    @include span-columns(4);
+    clear: none;
+    padding-top: 0;
+  }
+}
+
+// BREAKPOINT: LARGE
+@include media($lg) {
+
 }


### PR DESCRIPTION
Here's the styles for the new cycle selects, based off https://github.com/18F/openFEC-web-app/issues/942

Some of the alignment isn't quite right (for various reasons I can explain), but it's getting close. I'd vote to merge now and make fine-tuning changes after we've verified that in general this is working for folks.

![gif](http://g.recordit.co/35eGw2IVSr.gif)

Requires https://github.com/18F/openFEC-web-app/pull/950