### PR TITLE
Makes glossary terms .2 rem smaller, bold

### DIFF
--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -41,6 +41,8 @@
 
   .glossary-term {
     margin: 0;
+    font-size: 1.6rem;
+    font-weight: bold;
   }
 
   .glossary-definition {


### PR DESCRIPTION
The glossary terms felt pretty large compared to the rest of the panel. This bumps them down just a tiny bit.

**BEFORE**
<img width="1280" alt="screen shot 2015-12-18 at 2 08 28 pm" src="https://cloud.githubusercontent.com/assets/11636908/11908756/0838fdd2-a5ad-11e5-9e10-762588bdb357.png">


**AFTER**
<img width="1279" alt="screen shot 2015-12-18 at 2 08 54 pm" src="https://cloud.githubusercontent.com/assets/11636908/11908750/0240e94e-a5ad-11e5-8896-ff66aaab8745.png">
