### PR TITLE
Set feedback toggle z-index to max.

### DIFF
--- a/scss/modules/_feedback.scss
+++ b/scss/modules/_feedback.scss
@@ -69,6 +69,7 @@
   bottom: 0;
   position: fixed;
   right: 4rem;
+  z-index: $z-feedback;
 }
 
 .feedback__button {


### PR DESCRIPTION
So the feedback toggle is always visible:

<img width="1237" alt="screen shot 2015-12-23 at 11 03 53 am" src="https://cloud.githubusercontent.com/assets/1633460/11980086/2825b7cc-a966-11e5-8e45-e3549b92e8c5.png">
