### PR TITLE
Tooltip styling

### DIFF
--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -17,7 +17,7 @@
   border: 2px solid $primary;
   background-color: $cream;
   font-family: $sans-serif;
-  padding: .3rem .5rem;
+  padding: 1.5rem;
   position: absolute;
   text-align: center;
   z-index: $z-tooltip;

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -35,7 +35,7 @@
   text-align: left;
   line-height: 1.2;
   margin-bottom: 0;
-  padding: .5rem;
+  padding: 1.5rem;
 
   a {
     border-bottom-color: $primary;

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -34,7 +34,7 @@
   color: $primary;
   text-align: left;
   font-size: 1.4rem;
-  line-height: 1.2;
+  line-height: 1.4;
   margin-bottom: 0;
   padding: 1.5rem;
 

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -29,14 +29,13 @@
   font-weight: bold;
 }
 
-// .tooltip__content      - Use to add extra padding and left align a paragraph of text in a tooltip
+// .tooltip__content      - Use to left align a paragraph of text in a tooltip
 .tooltip__content.tooltip__content { // Hack to override any font color styles on the parent element
   color: $primary;
   text-align: left;
   font-size: 1.4rem;
   line-height: 1.4;
   margin-bottom: 0;
-  padding: 1.5rem;
 
   a {
     border-bottom-color: $primary;

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -33,6 +33,7 @@
 .tooltip__content.tooltip__content { // Hack to override any font color styles on the parent element
   color: $primary;
   text-align: left;
+  font-size: 1.4rem;
   line-height: 1.2;
   margin-bottom: 0;
   padding: 1.5rem;


### PR DESCRIPTION
### Changes:

**Previous:**
Font sizes are inconsistent (some places 1.6, some 1.4rem, padding is too tight and has different values in different places.
<img width="308" alt="screen shot 2015-12-30 at 10 56 55 am" src="https://cloud.githubusercontent.com/assets/11636908/12053308/b1bc7ba4-aee5-11e5-97d0-b9bf7904c3b3.png">
<img width="237" alt="screen shot 2015-12-30 at 11 06 48 am" src="https://cloud.githubusercontent.com/assets/11636908/12053311/b4cda480-aee5-11e5-86c4-83c65b5a75f6.png">

**Updated:**
Font sizes are made consistent @ 1.4rem, padding is set universally to 1.5rem, increased line height for legibility.
<img width="310" alt="screen shot 2015-12-30 at 11 05 47 am" src="https://cloud.githubusercontent.com/assets/11636908/12053326/df81f424-aee5-11e5-81a9-aaa7fc16cb4e.png">
<img width="218" alt="screen shot 2015-12-30 at 11 07 15 am" src="https://cloud.githubusercontent.com/assets/11636908/12053328/e2bc15c0-aee5-11e5-948a-2903dc3d6201.png">

### Review:
@noahmanger 