### PR TITLE
Styling calendar

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -70,10 +70,8 @@ FilterSet.prototype.handleTagRemove = function(e) {
 
   if (type === 'checkbox' || type === 'radio') {
     $input.attr('checked', false).trigger('change');
-  }
-
-  if (type === 'text') {
-    $input.val().trigger('change');
+  } else if (type === 'text') {
+    $input.val('').trigger('change');
   }
 };
 

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 
 var events = require('./events');
 
-var TAGTEMPLATE = _.template(
+var TAG_TEMPLATE = _.template(
   '<li class="tag">' +
     '{{ text }}' +
     '<button class="button tag__remove">' +
@@ -24,9 +24,7 @@ function TagList() {
 }
 
 TagList.prototype.addTag = function(opts) {
-  if (this.findTag(opts.key)) {
-    this.removeTag(opts);
-  }
+  this.removeTag(opts);
 
   var tag = new Tag(opts);
   this.tags[tag.key] = tag;
@@ -34,23 +32,18 @@ TagList.prototype.addTag = function(opts) {
 };
 
 TagList.prototype.removeTag = function(opts) {
-  if (Object.keys(this.tags).length > 0 && this.findTag(opts.key)) {
-    var tag = this.findTag(opts.key);
+  var tag = this.tags[opts.key];
+  if (tag) {
     delete this.tags[tag.key];
     tag.remove();
   }
 };
 
-TagList.prototype.findTag = function(key) {
-  return this.tags[key] || null;
-};
-
 function Tag(opts) {
   this.key = opts.key;
-  this.checkOrRadio = opts.type === 'checkbox' || opts.type === 'radio';
   this.text = opts.value;
 
-  this.$content = $(TAGTEMPLATE({text: this.text}));
+  this.$content = $(TAG_TEMPLATE({text: this.text}));
   this.$content.on('click', 'button', this.remove.bind(this, true));
 }
 

--- a/js/filters.js
+++ b/js/filters.js
@@ -137,9 +137,28 @@ function TypeaheadFilter(elm) {
   var key = this.$body.data('dataset');
   var dataset = typeahead.datasets[key];
   this.typeaheadFilter = new typeaheadFilter.TypeaheadFilter(this.$body, dataset);
+  this.typeaheadFilter.$body.on('change', 'input[type="checkbox"]', this.handleNestedChange.bind(this));
 }
 
 TypeaheadFilter.prototype = Object.create(Filter.prototype);
 TypeaheadFilter.constructor = TypeaheadFilter;
+
+TypeaheadFilter.prototype.handleChange = function() {};
+
+TypeaheadFilter.prototype.handleNestedChange = function(e) {
+  var $input = $(e.target);
+  var type = $input.attr('type');
+  var id = $input.attr('id');
+
+  var eventName = $input.is(':checked') ? 'filter:added' : 'filter:removed';
+  var value = $input.val();
+
+  events.emit(eventName,
+    {
+      key: id,
+      value: value,
+      type: type
+    });
+};
 
 module.exports = {Filter: Filter};

--- a/js/filters.js
+++ b/js/filters.js
@@ -27,8 +27,6 @@ function Filter(elm) {
   this.$input = this.$body.find('input[name]');
   this.$remove = this.$body.find('.button--remove');
 
-  this.tags = [];
-
   this.$input.on('change', this.handleChange.bind(this));
   this.$input.on('keydown', this.handleKeydown.bind(this));
   this.$remove.on('click', this.handleClear.bind(this));
@@ -73,21 +71,19 @@ Filter.prototype.handleKeydown = function(e) {
 };
 
 Filter.prototype.handleChange = function(e) {
-  var $input = $(e.target),
-      type = $input.attr('type'),
-      id = $input.attr('id'),
-      eventName,
-      value;
+  var $input = $(e.target);
+  var type = $input.attr('type');
+  var id = $input.attr('id');
+  var eventName;
+  var value;
 
   this.$remove.css('display', $input.val() ? 'block' : 'none');
 
   if (type === 'checkbox' || type === 'radio') {
     eventName = $input.is(':checked') ? 'filter:added' : 'filter:removed';
     value = $('label[for="' + id + '"]').text();
-  }
-
-  if (type === 'text') {
-    eventName = $input.val().length > 0 ? 'filter:added' : 'filter:removed';
+  } else if (type === 'text') {
+    eventName = $input.val().length ? 'filter:added' : 'filter:removed';
     value = $input.val();
   }
 

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -49,7 +49,9 @@ TypeaheadFilter.prototype.checkboxTemplate = _.template(
 );
 
 TypeaheadFilter.prototype.appendCheckbox = function(opts) {
-  $(this.checkboxTemplate(opts)).appendTo(this.$selected);
+  var checkbox = $(this.checkboxTemplate(opts));
+  checkbox.appendTo(this.$selected);
+  checkbox.find('input').change();
   this.$field.val(opts.id).change();
   this.clearInput();
 };


### PR DESCRIPTION
* Miscellaneous cleanup
* Make typeahead filters (kind of) work

Note: This implementation of typeahead filter tags shows candidate or committee IDs, rather than names. That's because when we load a page with IDs in the URL, we don't have the names right away--we have to get those via AJAX. While we're waiting, we show "Loading..." instead of the name by the checkbox elements. We *could* update both tags and checkbox labels on AJAX load, but that seems like overkill--it might be simpler just to hide the checkboxes entirely, then render on load.

Also, while I was looking at this patch, I noticed that some fields create ambiguous tags--date and money range filters don't distinguish between minimum and maximum values, for example.