### PR TITLE
Replace event emitter with custom DOM events.

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -65,7 +65,7 @@ FilterSet.prototype.clear = function() {
 
 FilterSet.prototype.handleTagRemove = function(e, opts) {
   var $input = this.$body.find('#' + opts.key);
-  var type = $input.attr('type') || 'text';
+  var type = $input.get(0).type;
 
   if (type === 'checkbox' || type === 'radio') {
     $input.attr('checked', false).trigger('change');

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -5,7 +5,6 @@ var _ = require('underscore');
 var URI = require('urijs');
 
 var Filter = require('./filters').Filter;
-var events = require('./events');
 
 var KEYCODE_ENTER = 13;
 
@@ -16,7 +15,7 @@ function FilterSet(elm, $tagContainer) {
 
   this.$clear.on('click keypress', this.handleClear.bind(this));
 
-  events.on('tag:removed', this.handleTagRemove.bind(this));
+  $(document.body).on('tag:removed', this.handleTagRemove.bind(this));
 
   this.filters = {};
   this.fields = [];
@@ -64,9 +63,9 @@ FilterSet.prototype.clear = function() {
   });
 };
 
-FilterSet.prototype.handleTagRemove = function(e) {
-  var $input = this.$body.find('#' + e.key);
-  var type = $input.attr('type');
+FilterSet.prototype.handleTagRemove = function(e, opts) {
+  var $input = this.$body.find('#' + opts.key);
+  var type = $input.attr('type') || 'text';
 
   if (type === 'checkbox' || type === 'radio') {
     $input.attr('checked', false).trigger('change');

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -16,7 +16,7 @@ var BODY_TEMPLATE = _.template(
 var TAG_TEMPLATE = _.template(
   '<li data-id="{{ key }}" class="tag">' +
     '{{ value }}' +
-    '<button class="button tag__remove">' +
+    '<button class="button js-close tag__remove">' +
       '<span class="u-visually-hidden">Remove</span>' +
     '</button>' +
   '</li>',
@@ -35,7 +35,7 @@ function TagList(opts) {
     .on('filter:removed', this.removeTagEvt.bind(this))
     .on('filter:renamed', this.renameTag.bind(this));
 
-  this.$list.on('click', '.tag', this.removeTagDom.bind(this));
+  this.$list.on('click', '.js-close', this.removeTagDom.bind(this));
 }
 
 TagList.prototype.addTag = function(e, opts) {
@@ -47,7 +47,7 @@ TagList.prototype.addTag = function(e, opts) {
 };
 
 TagList.prototype.removeTag = function(key, emit) {
-  var $tag = this.$list.find('#' + key);
+  var $tag = this.$list.find('[data-id="' + key + '"]');
   if ($tag.length) {
     if (emit) {
       $tag.trigger('tag:removed', [{key: key}]);
@@ -65,7 +65,7 @@ TagList.prototype.removeTagEvt = function(e, opts) {
 };
 
 TagList.prototype.removeTagDom = function(e) {
-  var key = $(e.target).closest('.tag').attr('id');
+  var key = $(e.target).closest('.tag').data('id');
   this.removeTag(key, true);
 };
 

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -3,8 +3,6 @@
 var $ = require('jquery');
 var _ = require('underscore');
 
-var events = require('./events');
-
 var BODY_TEMPLATE = _.template(
   '<div class="data-container__tags">' +
     '<h3 class="tags__title">Viewing: ' +
@@ -16,7 +14,7 @@ var BODY_TEMPLATE = _.template(
 );
 
 var TAG_TEMPLATE = _.template(
-  '<li id="{{ key }}" class="tag">' +
+  '<li data-id="{{ key }}" class="tag">' +
     '{{ value }}' +
     '<button class="button tag__remove">' +
       '<span class="u-visually-hidden">Remove</span>' +
@@ -32,14 +30,15 @@ function TagList(opts) {
   this.$list = this.$body.find('ul');
   this.$title = this.$body.find('.js-tag-title');
 
-  events.on('filter:added', this.addTag.bind(this));
-  events.on('filter:removed', this.removeTagEvt.bind(this));
-  events.on('filter:renamed', this.renameTag.bind(this));
+  $(document.body)
+    .on('filter:added', this.addTag.bind(this))
+    .on('filter:removed', this.removeTagEvt.bind(this))
+    .on('filter:renamed', this.renameTag.bind(this));
 
   this.$list.on('click', '.tag', this.removeTagDom.bind(this));
 }
 
-TagList.prototype.addTag = function(opts) {
+TagList.prototype.addTag = function(e, opts) {
   this.removeTag(opts.key, false);
   this.$title.html('');
 
@@ -50,10 +49,10 @@ TagList.prototype.addTag = function(opts) {
 TagList.prototype.removeTag = function(key, emit) {
   var $tag = this.$list.find('#' + key);
   if ($tag.length) {
-    $tag.remove();
     if (emit) {
-      events.emit('tag:removed', {key: key});
+      $tag.trigger('tag:removed', [{key: key}]);
     }
+    $tag.remove();
   }
 
   if (this.$list.find('.tag').length === 0) {
@@ -61,7 +60,7 @@ TagList.prototype.removeTag = function(key, emit) {
   }
 };
 
-TagList.prototype.removeTagEvt = function(opts) {
+TagList.prototype.removeTagEvt = function(e, opts) {
   this.removeTag(opts.key, false);
 };
 
@@ -70,7 +69,7 @@ TagList.prototype.removeTagDom = function(e) {
   this.removeTag(key, true);
 };
 
-TagList.prototype.renameTag = function(opts) {
+TagList.prototype.renameTag = function(e, opts) {
   var $tag = this.$list.find('#' + opts.key);
   if ($tag.length) {
     $tag.replaceWith(TAG_TEMPLATE(opts));

--- a/js/filters.js
+++ b/js/filters.js
@@ -6,7 +6,6 @@ var _ = require('underscore');
 // Hack: Append jQuery to `window` for use by legacy libraries
 window.$ = window.jQuery = $;
 
-var events = require('./events');
 var typeahead = require('./typeahead');
 var typeaheadFilter = require('./typeahead-filter');
 
@@ -72,7 +71,7 @@ Filter.prototype.handleKeydown = function(e) {
 
 Filter.prototype.handleChange = function(e) {
   var $input = $(e.target);
-  var type = $input.attr('type');
+  var type = $input.attr('type') || 'text';
   var prefix = $input.data('prefix');
   var suffix = $input.data('suffix');
   var id = $input.attr('id');
@@ -96,12 +95,12 @@ Filter.prototype.handleChange = function(e) {
     value = value + ' ' + suffix;
   }
 
-  events.emit(eventName,
+  $input.trigger(eventName, [
     {
       key: id,
       value: value,
-      type: type
-    });
+    }
+  ]);
 };
 
 function DateFilter(elm) {
@@ -156,18 +155,17 @@ TypeaheadFilter.prototype.handleChange = function() {};
 
 TypeaheadFilter.prototype.handleNestedChange = function(e) {
   var $input = $(e.target);
-  var type = $input.attr('type');
   var id = $input.attr('id');
   var $label = this.$body.find('[for="' + id + '"]');
 
   var eventName = $input.is(':checked') ? 'filter:added' : 'filter:removed';
 
-  events.emit(eventName,
+  $input.trigger(eventName, [
     {
       key: id,
       value: $label.text(),
-      type: type
-    });
+    }
+  ]);
 };
 
 module.exports = {Filter: Filter};

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -6,8 +6,6 @@ var $ = require('jquery');
 var URI = require('urijs');
 var _ = require('underscore');
 
-var events = require('./events');
-
 var TypeaheadFilter = function(selector, dataset) {
   var self = this;
 
@@ -82,7 +80,12 @@ TypeaheadFilter.prototype.getFilters = function() {
     ).done(function(response) {
       _.each(response.results, function(result) {
         self.$body.find('label[for="' + result[idKey] + '-checkbox"]').text(result.name);
-        events.emit('filter:renamed', {key: result[idKey] + '-checkbox', value: result.name});
+        self.$body.find('#' + idKey).trigger('filter:renamed', [
+          {
+            key: result[idKey] + '-checkbox',
+            value: result.name
+          }
+        ]);
       });
     });
   }


### PR DESCRIPTION
Two motivations for this change:

* Prefer native browser functionality over third-party modules
* Using eventemitter requires that all modules that share events use the same event dispatcher, which is all right for now but could get complicated if we continue splitting off components into separate repos.

Ping @noahmanger 