### PR TITLE
Small pre-release fixes

### DIFF
--- a/scss/components/_results-info.scss
+++ b/scss/components/_results-info.scss
@@ -91,7 +91,7 @@
     }
 
     .dataTables_length {
-      padding: 0;
+      padding: 0 1rem 0 0;
     }
 
     .dataTables_paginate {

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -91,6 +91,7 @@
     }
 
     .tt-menu {
+      font-size: 1.6rem;
       top: 5.9rem !important;
       width: calc(100% - 10.2rem);
     }
@@ -105,8 +106,9 @@
 
 .tt-menu {
   background-color: $cream;
-  border: 1px solid $ivory;
+  border: 1px solid $primary;
   font-family: $sans-serif;
+  font-size: 1.2rem;
   left: 0;
   text-align: left;
   position: absolute;

--- a/scss/modules/_data-container.scss
+++ b/scss/modules/_data-container.scss
@@ -53,13 +53,13 @@
 
 @include media($lg) {
   .data-container {
+    float: left;
     padding: 0;
   }
 
   .is-showing-filters {
     .data-container {
       width: calc(100% - 30rem);
-      float: left;
     }
   }
 

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -133,11 +133,6 @@
   .twitter-typeahead {
     height: auto;
   }
-
-  .tt-dropdown-menu {
-    font-size: 1.2rem;
-    width: 100%;
-  }
 }
 
 // Color-coding


### PR DESCRIPTION
- Adds padding between the datatable length select and the page arrows
- Correctly styles the typeahead dropdown, which was renamed in the new
version
- Correctly applies float to the data-container to prevent weirdness
when closing the filter panel