### PR TITLE
Improve typeahead interaction

### DIFF
--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -36,12 +36,17 @@ var textDataset = {
 var TypeaheadFilter = function(selector, dataset, allowText) {
   this.$body = $(selector);
   this.dataset = dataset;
+  this.allowText = allowText;
 
   this.$field = this.$body.find('input[type="text"]');
   this.fieldName = this.$body.data('name') || this.$field.attr('name');
+  this.$button = this.$body.find('button');
   this.$selected = this.$body.find('.dropdown__selected');
   this.$field.on('typeahead:selected', this.handleSelect.bind(this));
-  if (allowText) {
+  this.$field.on('typeahead:autocomplete', this.handleAutocomplete.bind(this));
+  this.$field.on('keyup', this.handleKeypress.bind(this));
+  this.$button.on('click', this.handleSubmit.bind(this));
+  if (this.allowText) {
     this.$field.typeahead({minLength: 3}, textDataset, this.dataset);
   } else {
     this.$field.typeahead({minLength: 3}, this.dataset);
@@ -55,6 +60,24 @@ TypeaheadFilter.prototype.handleSelect = function(e, datum) {
     value: datum.id,
     id: this.fieldName + '-' + slugify(datum.id) + '-checkbox'
   });
+};
+
+TypeaheadFilter.prototype.handleAutocomplete = function(e, datum) {
+  this.datum = datum;
+};
+
+TypeaheadFilter.prototype.handleKeypress = function(e) {
+  if (e.keyCode === 13) {
+    this.handleSubmit(e);
+  }
+};
+
+TypeaheadFilter.prototype.handleSubmit = function(e) {
+  if (this.datum) {
+    this.handleSelect(e, this.datum);
+  } else if (this.allowText && this.$field.typeahead('val').length > 0) {
+    this.handleSelect(e, {id: this.$field.typeahead('val')});
+  }
 };
 
 TypeaheadFilter.prototype.clearInput = function() {

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -53,7 +53,7 @@ TypeaheadFilter.prototype.handleSelect = function(e, datum) {
     name: this.fieldName,
     label: formatLabel(datum),
     value: datum.id,
-    id: slugify(datum.id) + '-checkbox'
+    id: this.fieldName + '-' + slugify(datum.id) + '-checkbox'
   });
 };
 


### PR DESCRIPTION
Since the release got pushed back a day, I wanted to take the time to sand off a couple rough edges that were nagging me with the typeahead filters. 

Previously, the only way to select a typeahead filter was by clicking (or arrowing-down and hitting enter) on an option in the list. With this patch, you can now:

### 1. Hit enter in the input
If the input accepts free text, it turns the text entry into the filter:
![image](http://g.recordit.co/ODXZGMZCE8.gif)

If it accepts only typeahead suggestions, it uses that:
![image](http://g.recordit.co/Y36yMysVel.gif)

### 2. Click the button 
For free text:
![image](http://g.recordit.co/2stFfE3RQL.gif)

For suggestions (you must hit tab in order to complete the autocomplete suggestion):
![image](http://g.recordit.co/o2FQdInnMw.gif)

There might still be ways we can improve this, but the more I used it the more this stuck out as things that would be good to fix. It shouldn't hold up launch, but if it's straightforward enough, I think it would be worth including.

@jmcarp or @ccostino can one of you take a look?