### PR TITLE
Adding required signifier to feedback form

### DIFF
--- a/js/templates/feedback.html
+++ b/js/templates/feedback.html
@@ -10,7 +10,7 @@
       <fieldset>
         <legend class="feedback__title">Help us improve betaFEC</legend>
         <p class="t-sans">Don't include sensitive information like your name, contact information or Social Security number.</p>
-        <label for="feedback-1" class="label">What were you trying to do and how can we improve it?</label>
+        <label for="feedback-1" class="label">What were you trying to do and how can we improve it?*</label>
         <textarea id="feedback-1" name="action"></textarea>
         <label for="feedback-2" class="label">General feedback?</label>
         <textarea id="feedback-2" name="feedback"></textarea>
@@ -18,6 +18,7 @@
         <span class="label--help">I'm a <span class="u-blank-space"></span> interested in <span class="u-blank-space"></span>.</span>
         <textarea id="feedback-3" name="about"></textarea>
         <p class="t-sans">This information will be reported on GitHub where it will be publicly visible. You can review all reported feedback on <a href="https://github.com/18f/fec/issues">our GitHub page</a>.</p>
+        <p class="t-sans t-note">*Required</p>
         <button type="submit" class="button--primary feedback__button">Submit</button>
       </fieldset>
     </form>


### PR DESCRIPTION
Resolves https://github.com/18F/FEC/issues/270

Note, I moved the "*Required" note to below the disclaimer paragraph, rather than above:

![image](https://cloud.githubusercontent.com/assets/1696495/14092958/2a81105e-f4ff-11e5-9f10-af2b44141a35.png)
