### PR TITLE
fec-style specific contributing guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+_Include a summary of all work and changes._
+
+## Screenshots
+
+- _Update the styleguide documentation, include a screenshot if applicable._
+- _Include a screenshot of the new/updated styles in context (“in the wild”)._
+
+
+_cc @username_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ Unknown tasks or dependencies that need investigation
 - When a pull request is ready for review, label it `plz-review`. 
 - Include a summary of all work and changes.
 - Use `cc @username` to notify a specific team member to review a pull request.
+- Update the styleguide documentation, include a screenshot if applicable.
+- Include a screenshot of the new/updated styles in context (“in the wild”).
 
 ## 18F team processes
 * Use PEP8 as the coding standard for Python, but don't worry about fitting lines within 79 characters.


### PR DESCRIPTION
As discussed in our fec-style meeting on 2015-03-25.
https://docs.google.com/document/d/1H-_P6nX4WRoZfCeZ_jJcF5lg0k5BgPfwvnUhrBsBDwo/edit

I started by adding two lines to `CONTRIBUTING.md`, but I'm afraid it will get lost since there is a ton of content in there covering all of our projects. I know @ccostino  and @emileighoutlaw are re-doing some of the `README` content, but not sure if the `CONTRIBUTING` docs are part of that.

I've never used the github templates before, but figured this would be a good chance to try them out so that our `fec-style` contributing guidelines are in your face when submitting a PR.

cc @noahmanger @jenniferthibault