### PR TITLE
Styles for legal search results

### DIFF
--- a/scss/components/_side-nav.scss
+++ b/scss/components/_side-nav.scss
@@ -9,7 +9,7 @@
 //       <li class="side-nav__item"><a class="side-nav__link is-active" href="#">Link (active)</a></li>
 //       <li class="side-nav__item"><a class="side-nav__link" href="#">Link</a></li>
 //       <li class="side-nav__item"><a class="side-nav__link" href="#">Link</a></li>
-//       <li class="side-nav__item"><a class="side-nav__link" href="#">Link</a></li>
+//       <li class="is-disabled side-nav__item"><span class="side-nav__link" href="#">TBD</span></li>
 //     </ul>
 //   </nav>
 // </div>
@@ -29,6 +29,15 @@
 
   &:last-child {
     padding-bottom: 0;
+  }
+
+  &.is-disabled {
+    .side-nav__link {
+      &:hover,
+      &:focus {
+        background-color: transparent;
+      }
+    }
   }
 }
 

--- a/scss/components/_type-styles.scss
+++ b/scss/components/_type-styles.scss
@@ -90,6 +90,7 @@
 // .t-block         - Force display: block
 // .t-inline-block  - Force display: inline-block
 // .t-sans          - Force sans serif
+// .t-serif         - Force serif
 // .t-italic        - Italicize
 // .t-bold          - Embolden!
 // .t-upper         - Transform to uppercase
@@ -128,6 +129,10 @@
 .t-sans {
   font-family: $sans-serif;
   letter-spacing: -.3px;
+}
+
+.t-serif {
+  font-family: $serif;
 }
 
 .t-italic {

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -1,6 +1,7 @@
 // Datatables
 //
 // .is-showing-filters    - Class applied to body when the filters are open, causing the datatable to shrink slightly
+// .data-table--text      - Textual tables for text-heavy search results.
 //
 // Styleguide modules.datatables
 
@@ -78,6 +79,14 @@
     table-layout: auto;
   }
 }
+
+.data-table--text {
+  td {
+    white-space: normal;
+    vertical-align: top;
+  }
+}
+
 
 // Special styles for rows that trigger panels
 .row--has-panel {
@@ -164,5 +173,42 @@
 
   @include media($med) {
     @include span-columns(9);
+  }
+}
+
+// Datatable cell widths
+//
+// Adjust cell widths by percentage.
+//
+// .cell--5  - 5% width
+// .cell--10 - 10% width
+// .cell--15 - 15% width
+// .cell--20 - 20% width
+// .cell--25 - 25% width
+// .cell--30 - 30% width
+// .cell--35 - 35% width
+// .cell--40 - 40% width
+// .cell--45 - 45% width
+// .cell--50 - 50% width
+// .cell--55 - 55% width
+// .cell--60 - 60% width
+// .cell--65 - 65% width
+// .cell--70 - 70% width
+// .cell--75 - 75% width
+// .cell--80 - 80% width
+// .cell--85 - 85% width
+// .cell--90 - 90% width
+// .cell--95 - 95% width
+//
+// Styleguide modules.datatables.cell-widths
+@mixin cell-width($width) {
+  width: $width * 1%;
+}
+
+@for $i from 1 to 20 {
+  $width: $i * 5;
+
+  .cell--#{$width} {
+    @include cell-width($width);
   }
 }

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -29,6 +29,11 @@
   margin-top: 1rem;
 }
 
+.results-info__secondary {
+  line-height: 2;
+  font-family: $sans-serif;
+}
+
 .results-info--top {
   border-top: none;
 }

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -29,7 +29,7 @@
   margin-top: 1rem;
 }
 
-.results-info__secondary {
+.results-info__details {
   line-height: 2;
   font-family: $sans-serif;
 }


### PR DESCRIPTION
## Summary

Added some minor styles in order to implement the [Legal search results page](https://projects.invisionapp.com/share/5N6NL76QM#/screens/145835130). [Trello](https://trello.com/c/g0MX7L9w/62-hook-ui-up-to-search-api).

- Disabled `side-nav` links
- Datatable suitable for text.
- Classes for adjusting datatable cell widths
- Secondary text for the `results-info` header

## Screenshots

![screenshot from 2016-04-08 18-31-18](https://cloud.githubusercontent.com/assets/509703/14401016/37b81a80-fdb8-11e5-8144-900290e1e04e.png)


cc @edmullen @noahmanger @jenniferthibault