### PR TITLE
Calendar bug fixes

### DIFF
--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -156,6 +156,18 @@
   }
 }
 
+.fc-multi-day {
+  .fc-content {
+    border: 1px solid $gray;
+    border-radius: 2px;
+    padding-left: 2px;
+
+    &::before {
+      display: none;
+    }
+  }
+}
+
 .is-active {
   .fc-content {
     background-color: $primary;

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -214,7 +214,7 @@
   }
 }
 
-.fc-event-container:last-child {
+.fc-event-container:nth-child(7) {
   .cal-details {
     right: 0;
 


### PR DESCRIPTION
## Summary
- Adds multi-day event style
- Correctly only sets tooltips for the last day of the week to be `right: 0` rather than `:last-child`, which was causing some tooltips to not line up with events.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/14441511/ebb9bc22-ffe9-11e5-974d-37072900ce01.png)

## Related
https://github.com/18F/fec-cms/pull/271