### PR TITLE
Setting option styles for firefox and ubuntu chrome

### DIFF
--- a/scss/components/_form-styles.scss
+++ b/scss/components/_form-styles.scss
@@ -64,14 +64,17 @@
   }
 
   &:active:not(.is-disabled):not([disabled]),
+  &:focus,
   &.is-active {
     background-color: rgba($inverse, .3);
     border-color: $primary-contrast;
     color: $inverse;
   }
 
-  &:focus {
-    color: $inverse;
+  option {
+    background-color: $neutral;
+    color: $primary;
+    padding: .5rem;
   }
 }
 
@@ -87,6 +90,7 @@
   }
 
   &:active:not(.is-disabled):not([disabled]),
+  &:focus,
   &.is-active {
     background-color: rgba($inverse, .3);
     border-color: $secondary-contrast;
@@ -95,6 +99,12 @@
 
   &:focus {
     color: $inverse;
+  }
+
+  option {
+    background-color: $neutral;
+    color: $primary;
+    padding: .5rem;
   }
 }
 


### PR DESCRIPTION
## Summary

Sets the background of the `option` elements inside selects, which is necessary for certain browsers, like Chrome on Ubuntu. Firefox intelligently styles them correctly, but respects the styles included. Chrome and Safari on OSX ignor 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1696495/14446226/8534f0e2-0008-11e6-8f98-000e5983e7d6.png)

cc @adborden