### PR TITLE
Fixing truncated text

### DIFF
--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -157,7 +157,7 @@
   }
 
   &::after {
-    @include linear-gradient(90deg, rgba($inverse, 0), $inverse)
+    @include linear-gradient(90deg, rgba($inverse, 0), $inverse);
     content: '';
     display: block;
     position: absolute;

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -136,7 +136,8 @@
 }
 
 .fc-content {
-  @include u-truncate();
+  white-space: nowrap;
+  overflow: hidden;
   background: none;
   color: $primary;
   font-size: 1.4rem;
@@ -153,6 +154,17 @@
     border-radius: .8rem;
     float: left;
     margin: 5px 5px 5px 0;
+  }
+
+  &::after {
+    @include linear-gradient(90deg, rgba($inverse, 0), $inverse)
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 3rem;
   }
 }
 
@@ -176,6 +188,11 @@
 
     &::before {
       background-color: $inverse;
+    }
+
+    &::after {
+      display: none;
+      background-color: transparent;
     }
   }
 }


### PR DESCRIPTION
Fixes the issue of issue of truncated text in the calendar not showing up on firefox. I replaced the ellipsis with a gradient like so:

![image](https://cloud.githubusercontent.com/assets/1696495/14508600/1d05f810-017d-11e6-9f16-ad59558ebd7d.png)
