### PR TITLE
Restore page header style

### DIFF
--- a/scss/components/_page-headers.scss
+++ b/scss/components/_page-headers.scss
@@ -43,6 +43,15 @@
   background: $secondary;
 }
 
+.page-header__title {
+  border-bottom: none;
+  font-family: $sans-serif;
+  font-size: 1.6rem;
+  text-transform: uppercase;
+  margin-bottom: 0;
+  line-height: 1;
+}
+
 // BREAKPOINT: MEDIUM
 // Add padding
 // Show the search bar in line with the page title


### PR DESCRIPTION
This restores a class that I pulled out in the breadcrumb refactor, but which is still active in the web app for the time being.