### PR TITLE
New styles for Legal search

### DIFF
--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -18,6 +18,7 @@
 @import 'form-styles';
 @import 'icon-headings';
 @import 'icons';
+@import 'legal-search';
 @import 'list-styles';
 @import 'maps'; //@TODO: Address later
 @import 'messages';

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -11,3 +11,7 @@
     @include t-highlight;
   }
 }
+
+.legal-search-result__display-all {
+  margin: 0.5em 0;
+}

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -1,0 +1,13 @@
+// Legal search
+//
+// Styles for legal search results.
+//
+// Styleguide components.search-results-legal
+
+.legal-search-result__hit {
+  font-style: italic;
+
+  em {
+    @include t-highlight;
+  }
+}

--- a/scss/components/_type-styles.scss
+++ b/scss/components/_type-styles.scss
@@ -93,6 +93,7 @@
 // .t-serif         - Force serif
 // .t-italic        - Italicize
 // .t-bold          - Embolden!
+// .t-highlight     - Highlight
 // .t-upper         - Transform to uppercase
 // .t-data-header   - Small header above a big data number
 // .t-big-data      - Big number
@@ -141,6 +142,10 @@
 
 .t-bold {
   font-weight: bold;
+}
+
+.t-hightlight {
+  @include t-highlight;
 }
 
 .t-upper {

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -73,3 +73,9 @@
     text-transform: uppercase;
   }
 }
+
+@mixin t-highlight {
+  background: $gray-light;
+  font-weight: bold;
+  padding: 0 0.3em;
+}


### PR DESCRIPTION
## Summary

Some new style elements for Legal search.

- Term highlighting within search result snippets
- display-all link to the document specific search page

## Screenshots

`.t-highlight`
![screenshot from 2016-04-22 18-09-12](https://cloud.githubusercontent.com/assets/509703/14758397/69d7582a-08b5-11e6-9282-ff16202e7292.png)
--
![screenshot from 2016-04-22 18-24-32](https://cloud.githubusercontent.com/assets/509703/14758490/832a0622-08b7-11e6-8155-5fd28011f4e4.png)

cc @noahmanger  @edmullen @jenniferthibault 
