### PR TITLE
Fixes glossary definition

### DIFF
--- a/js/terms.json
+++ b/js/terms.json
@@ -146,7 +146,7 @@
   },
       {
     "term": "Party committee",
-    "definition": "Public funding of presidential elections means that qualified presidential candidates may choose to receive federal government funds to pay for certain expenses of their political campaigns in both the primary and general elections. Prior to the 2016 presidential election, national political parties could also receive federal money for their national nominating conventions."
+    "definition": "A political committee that represents a political party and is part of the official party structure at the national, state or local level. "
   },
   {
     "term": "Exempt party activities",


### PR DESCRIPTION
Content only: I copied the wrong definition into the glossary under political party. This is the correct one. 

cc @ccostino 

