### PR TITLE
Add a few subclasses for doc legal search

### DIFF
--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -1,5 +1,41 @@
 // Datatables
 //
+// Standard design for tabular data. If the table is
+// preceded/followed by buttons (or nav arrows), always enclose with
+// a rule line using `.results-info`.
+//
+// Markup:
+// <table id="data-table" class="data-table {{ modifier_class }}">
+//   <thead>
+//     <tr>
+//       <th>No.</th>
+//       <th>Name</th>
+//       <th>Score</th>
+//     </tr>
+//   </thead>
+//   <tbody>
+//     <tr>
+//       <td>1</td>
+//       <td>Red</td>
+//       <td>0.1234</td>
+//     </tr>
+//     <tr>
+//       <td>2</td>
+//       <td>Blue</td>
+//       <td>0.1234</td>
+//     </tr>
+//     <tr>
+//       <td>3</td>
+//       <td>Green</td>
+//       <td>0.1234</td>
+//     </tr>
+//   </tbody>
+// </table>
+// <div class="results-info">
+//   <a class="paginate_button previous" href="#data-table">Previous</a>
+//   <a class="paginate_button next" href="#data-table">Next</a>
+// </div>
+//
 // .is-showing-filters    - Class applied to body when the filters are open, causing the datatable to shrink slightly
 // .data-table--text      - Textual tables for text-heavy search results.
 //

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -11,6 +11,7 @@
 //       <th>No.</th>
 //       <th>Name</th>
 //       <th>Score</th>
+//       <th>Description</th>
 //     </tr>
 //   </thead>
 //   <tbody>
@@ -18,16 +19,19 @@
 //       <td>1</td>
 //       <td>Red</td>
 //       <td>0.1234</td>
+//       <td>Minim in magna ex incididunt sit laborum exercitation aute do ullamco consectetur esse.</td>
 //     </tr>
 //     <tr>
 //       <td>2</td>
 //       <td>Blue</td>
 //       <td>0.1234</td>
+//       <td>in dolore amet irure dolore commodo est aliquip labore sunt</td>
 //     </tr>
 //     <tr>
 //       <td>3</td>
 //       <td>Green</td>
 //       <td>0.1234</td>
+//       <td>nostrud laborum in ullamco cillum laborum anim esse commodo aliqua</td>
 //     </tr>
 //   </tbody>
 // </table>

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -56,6 +56,10 @@
   }
 }
 
+.filters--fixed {
+  margin-right: 2rem;
+}
+
 .filters__hider {
   height: 0;
   overflow: hidden;

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -42,6 +42,10 @@
   border-top: none;
 }
 
+.results-info--bottom {
+  border-bottom: none;
+}
+
 .dataTables_wrapper {
   .results-info {
     font-family: $sans-serif;

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -1,6 +1,6 @@
 // Results Info
 //
-// The box of controls and info above and below datatables
+// The box of controls and info above and below datatables.
 //
 // Styleguide modules.results-info
 
@@ -34,16 +34,8 @@
   font-family: $sans-serif;
 }
 
-.results-info--top {
-  border-top: none;
-}
-
 .results-info--simple {
   border-top: none;
-}
-
-.results-info--bottom {
-  border-bottom: none;
 }
 
 .dataTables_wrapper {


### PR DESCRIPTION
## Summary

Adds a few styles needed for the legal document search results.

## Screenshots

`.filters--fixed`
![screenshot from 2016-05-02 11-58-30](https://cloud.githubusercontent.com/assets/509703/14959456/50cf603e-1044-11e6-82dc-de4568417d74.png)

`.results-info--bottom`
![screenshot from 2016-05-02 12-00-03](https://cloud.githubusercontent.com/assets/509703/14959459/5506d3e4-1044-11e6-9a61-b3271f218174.png)
