### PR TITLE
Remove `styleguide` dir on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build-sass && npm run build-js && npm run build-styleguide && npm run copy-css && npm run copy-images",
     "build-js": "browserify -t hbsfy --debug fec-template/public/init.js > fec-template/public/main.js",
     "build-sass": "node-sass scss/ -o css/",
-    "build-styleguide": "cd fec-template/ && npm run less && cd .. rm -rf styleguide && kss-node --config kss-config.json && npm run copy-css",
+    "build-styleguide": "cd fec-template/ && npm run less && cd .. && rm -rf styleguide && kss-node --config kss-config.json && npm run copy-css",
     "copy-images": "cp -R img styleguide/img",
     "copy-css": "cp -R css styleguide/css",
     "percy": "percy snapshot styleguide",


### PR DESCRIPTION
Fixes typo where `styleguide` directory is not removed on build.