### PR TITLE
Sticky bar

### DIFF
--- a/js/sticky-bar.js
+++ b/js/sticky-bar.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var $ = require('jquery');
+
+function StickyBar(selector) {
+  this.$body = $('body');
+  this.$bar = $(selector);
+  this.height = this.$bar.outerHeight();
+  this.offset = this.$bar.offset().top;
+  this.delay = 100; // Delay before it sticks
+
+  this.defaultBodyPadding = this.$body.css('padding-top');
+  $(window).on('scroll', this.toggle.bind(this));
+}
+
+StickyBar.prototype.toggle = function() {
+  var scrollTop = this.$body.scrollTop();
+  if (scrollTop >= this.offset + this.delay) {
+    this.$bar.addClass('is-stuck');
+    this.$body.css('padding-top', this.height);
+  } else if (scrollTop < this.offset) {
+    this.$bar.removeClass('is-stuck');
+    this.$body.css('padding-top', this.defaultBodyPadding);
+  }
+};
+
+module.exports = {StickyBar: StickyBar};

--- a/js/sticky-bar.js
+++ b/js/sticky-bar.js
@@ -5,9 +5,8 @@ var $ = require('jquery');
 function StickyBar(selector) {
   this.$body = $('body');
   this.$bar = $(selector);
-  this.height = this.$bar.outerHeight();
   this.offset = this.$bar.offset().top;
-  this.delay = 100; // Delay before it sticks
+  this.triggerOffset = this.$bar.data('trigger-offset'); // Delay before it sticks
 
   this.defaultBodyPadding = this.$body.css('padding-top');
   $(window).on('scroll', this.toggle.bind(this));
@@ -15,9 +14,10 @@ function StickyBar(selector) {
 
 StickyBar.prototype.toggle = function() {
   var scrollTop = this.$body.scrollTop();
-  if (scrollTop >= this.offset + this.delay) {
+  if (scrollTop >= this.offset + this.triggerOffset) {
+    var height = this.$bar.outerHeight();
     this.$bar.addClass('is-stuck');
-    this.$body.css('padding-top', this.height);
+    this.$body.css('padding-top', height);
   } else if (scrollTop < this.offset) {
     this.$bar.removeClass('is-stuck');
     this.$body.css('padding-top', this.defaultBodyPadding);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -56,13 +56,15 @@ $z3: 300;
 $z4: 400;
 $z5: 500;
 $z6: 600;
+$z7: 700;
+$z8: 800;
 $z-max: 9000000;
 
 $z-overlay: $z2;
 $z-tooltip: $z4;
-$z-sticky: $z4;
 $z-downloads: $z4;
 $z-navigation: $z5;
-$z-glossary: $z6;
 $z-header: $z6;
+$z-sticky: $z7;
+$z-glossary: $z8;
 $z-feedback: $z-max;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -60,7 +60,7 @@ $z-max: 9000000;
 
 $z-overlay: $z2;
 $z-tooltip: $z4;
-$z-page-controls: $z4;
+$z-sticky: $z4;
 $z-downloads: $z4;
 $z-navigation: $z5;
 $z-glossary: $z6;

--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -32,6 +32,7 @@
 @import 'search-results';
 @import 'side-nav';
 @import 'sidebar';
+@import 'stickybar';
 @import 'table-styles';
 @import 'tags';
 @import 'toggles';

--- a/scss/components/_stickybar.scss
+++ b/scss/components/_stickybar.scss
@@ -24,7 +24,6 @@
     top: -200px; // Setting this property so we can animate it when .is-stuck is applied
 
     &.is-stuck {
-      @include transition(top .4s ease-out);
       top: 0;
     }
   }

--- a/scss/components/_stickybar.scss
+++ b/scss/components/_stickybar.scss
@@ -1,0 +1,15 @@
+.sticky-bar {
+  @include transition(top .4s ease-out);
+  top: -200px; // Setting this property so we can animate it when .is-stuck is applied
+  z-index: $z-sticky;
+  width: 100%;
+
+  // To stick to the top of the page
+  &.is-stuck {
+    @include transition(top .4s ease-out);
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: $z-page-controls;
+  }
+}

--- a/scss/components/_stickybar.scss
+++ b/scss/components/_stickybar.scss
@@ -8,16 +8,24 @@
 // Styleguide components.sticky-bar
 
 .sticky-bar {
-  @include transition(top .4s ease-out);
-  top: -200px; // Setting this property so we can animate it when .is-stuck is applied
+  // @include transition(top .4s ease-out);
   z-index: $z-sticky;
   width: 100%;
 
   // To stick to the top of the page
   &.is-stuck {
-    @include transition(top .4s ease-out);
     position: fixed;
     top: 0;
     left: 0;
+  }
+
+  &.with-transition {
+    @include transition(top .4s ease-out);
+    top: -200px; // Setting this property so we can animate it when .is-stuck is applied
+
+    &.is-stuck {
+      @include transition(top .4s ease-out);
+      top: 0;
+    }
   }
 }

--- a/scss/components/_stickybar.scss
+++ b/scss/components/_stickybar.scss
@@ -10,6 +10,5 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: $z-page-controls;
   }
 }

--- a/scss/components/_stickybar.scss
+++ b/scss/components/_stickybar.scss
@@ -1,3 +1,12 @@
+// Sticky bar
+//
+// Styles for the sticky-bar JavaScript component
+// Use this class along with .js-sticky-bar to have a full-width bar stick to the top of the screen when you scroll past it.
+//
+// .sticky-bar
+//
+// Styleguide components.sticky-bar
+
 .sticky-bar {
   @include transition(top .4s ease-out);
   top: -200px; // Setting this property so we can animate it when .is-stuck is applied

--- a/scss/modules/_page-controls.scss
+++ b/scss/modules/_page-controls.scss
@@ -29,11 +29,8 @@
 // Styleguide modules.page-controls
 
 .page-controls {
-  @include transition(top .2s);
   @include clearfix();
   padding: 0 2rem;
-  top: -100px; // Setting this property so we can animate it when .is-stuck is applied
-  width: 100%;
 
   .container {
     padding: 0;
@@ -99,13 +96,8 @@
   }
 }
 
-// To stick to the top of the page
+// Show the hidden top part when stuck
 .is-stuck {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: $z-page-controls;
-
   .page-controls__top {
     display: block;
   }


### PR DESCRIPTION
## Summary

Adds a new JS component and related styles for sticky bars for use on candidate, committee and election pages (for the tabs), and on data pages (for the tag area). 

This is different than the other Sticky npm module we're using, which is used for the side-nav / table of contents on certain pages. That library is more complicated and works well for that task, but for reasons I was unable to figure out, couldn't handle this use case well. Ultimately it was just faster to write my own component to replace it for this scenario.

## Screenshots
![demo](http://g.recordit.co/2WjomCmmWi.gif)

