### PR TITLE
Adding support for changing typeahead suggestion

### DIFF
--- a/js/filter-control.js
+++ b/js/filter-control.js
@@ -3,30 +3,28 @@
 var $ = require('jquery');
 
 function FilterControl($selector) {
-  this.$body = $selector;
-  this.modifiesFilter = this.$body.data('modifies-filter');
-  this.modifiesProperty = this.$body.data('modifies-property');
-  this.getValue();
+  this.$element = $selector;
+  this.modifiesFilter = this.$element.data('modifies-filter');
+  this.modifiesProperty = this.$element.data('modifies-property');
 
-  this.controlledFilter = $('#' + this.$body.data('controls'));
-  this.$body.on('change', this.handleChange.bind(this));
+  this.controlledFilter = $('#' + this.$element.data('controls'));
+  this.$element.on('change', this.handleChange.bind(this));
 }
 
 FilterControl.prototype.getValue = function() {
   var values = [];
-  this.$body.find('input:checked').each(function() {
+  this.$element.find('input:checked').each(function() {
     values.push($(this).val());
   });
-  this.values = values;
+  return values;
 };
 
 FilterControl.prototype.handleChange = function() {
-  this.getValue();
-  this.$body.trigger('filter:modify', [
+  this.$element.trigger('filter:modify', [
     {
       filterName: this.modifiesFilter,
       filterProperty: this.modifiesProperty,
-      filterValue: this.values
+      filterValue: this.getValue()
     }
   ]);
 };

--- a/js/filter-control.js
+++ b/js/filter-control.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var $ = require('jquery');
+
+function FilterControl($selector) {
+  this.$body = $selector;
+  this.modifiesFilter = this.$body.data('modifies-filter');
+  this.modifiesProperty = this.$body.data('modifies-property');
+  this.getValue();
+
+  this.controlledFilter = $('#' + this.$body.data('controls'));
+  this.$body.on('change', this.handleChange.bind(this));
+}
+
+FilterControl.prototype.getValue = function() {
+  var values = [];
+  this.$body.find('input:checked').each(function() {
+    values.push($(this).val());
+  });
+  this.values = values;
+};
+
+FilterControl.prototype.handleChange = function() {
+  this.getValue();
+  this.$body.trigger('filter:modify', [
+    {
+      filterName: this.modifiesFilter,
+      filterProperty: this.modifiesProperty,
+      filterValue: this.values
+    }
+  ]);
+};
+
+module.exports = {FilterControl: FilterControl};

--- a/js/filters.js
+++ b/js/filters.js
@@ -8,6 +8,7 @@ window.$ = window.jQuery = $;
 
 var typeahead = require('./typeahead');
 var typeaheadFilter = require('./typeahead-filter');
+var FilterControl = require('./filter-control').FilterControl;
 
 var cyclesTemplate = require('./templates/election-cycles.hbs');
 
@@ -34,6 +35,10 @@ function Filter(elm) {
 
   this.name = this.$body.data('name') || this.$input.attr('name');
   this.fields = [this.name];
+
+  if (this.$body.hasClass('js-filter-control')) {
+    new FilterControl(this.$body);
+  }
 }
 
 Filter.build = function($elm) {
@@ -152,7 +157,7 @@ function TypeaheadFilter(elm) {
 
   var key = this.$body.data('dataset');
   var allowText = this.$body.data('allow-text') !== undefined;
-  var dataset = typeahead.datasets[key];
+  var dataset = key ? typeahead.datasets[key] : null;
   this.typeaheadFilter = new typeaheadFilter.TypeaheadFilter(this.$body, dataset, allowText);
   this.typeaheadFilter.$body.on('change', 'input[type="checkbox"]', this.handleNestedChange.bind(this));
 }


### PR DESCRIPTION
## Summary

Creates a simple version of a new `FilterControl` component which can be set to trigger `filter:modify` events that change the settings of a particular filter. The only instance of this currently is for changing the way the `contributor name` filter shows typeahead suggestions depending on if the filter above has only `individual` checked or not. 

As such, the code is not fully abstracted, but I think that's ok for now, and we can abstract later. 

Can you take a look @ccostino or @adborden ? If this looks like a good approach, I'll go ahead and add tests.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/15517198/64e6f212-21ab-11e6-8014-a2e1a96acba4.png)