### PR TITLE
Change five thousand flag to raised funds

### DIFF
--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -47,7 +47,7 @@
     <div class="mega__group">
       <div class="mega__column">
         <div class="mega-heading--sub">
-          <h4 class="mega-heading__title icon-heading--candidates"><a href="{{webAppUrl}}/candidates/?election_year=2012&election_year=2014&election_year=2016&five_thousand_flag=true">Candidates - all</a></h4>
+          <h4 class="mega-heading__title icon-heading--candidates"><a href="{{webAppUrl}}/candidates/?election_year=2012&election_year=2014&election_year=2016&has_raised_funds=true">Candidates - all</a></h4>
         </div>
         <ul>
           <li class="mega__item"><a href="{{webAppUrl}}/candidates/president">Presidential</a></li>


### PR DESCRIPTION
This changeset modifies the `five_thousand_flag` to match the new, updated flag of `has_raised_funds`. This is to support the change on the API side in https://github.com/18F/openFEC/pull/1689.

/cc @noahmanger