### PR TITLE
Feature/base size

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -1,0 +1,80 @@
+// Utility Functions
+//
+// Various useful functions.
+//
+// Weight: 90
+//
+// Styleguide functions
+
+// Unit conversion
+//
+// When using the FEC styleguide with other frameworks, it might be useful to
+// scale and convert the FEC component sizes. Use these variables to adjust how
+// the styleguide is built.
+//
+// $px-only - (bool) convert `rem` units to `px`
+// $base-size-px - (integer) sets the base size for a `rem` unit (only take effect when `$px-only` is true)
+//
+// Styleguide functions.convert-units
+$base-size-px: 10 !default;
+$px-only: false !default;
+
+// u-parse-int($n)
+//
+// Parses the integer part from a value with unit.
+//
+// $n - the value to parse e.g. 2em
+//
+// Styleguide functions.parse-int
+@function u-parse-int($n) {
+  @return $n / ($n * 0 + 1);
+}
+
+// u-scale-to-px($n)
+//
+// Scales the value according to `$base-size-px` and appends the `px` unit.
+//
+// $n - value to scale to `px`
+//
+// Styleguide functions.scale-to-px
+@function u-scale-to-px($n) {
+  @return $n * $base-size-px + px;
+}
+
+// u($values)
+//
+// Convert and/or scale `rem` units. This should be used on all
+// properties related to component size. This allows FEC styleguide
+// to scale component sizes properly.
+//
+// Inspired by https://github.com/saxinte/rem-to-px-revisited
+//
+// $values - single unit or list of units e.g. `1rem 1.2rem`
+//
+// Styleguide functions.convert-units.function
+@function u($values) {
+  $converted: ();
+
+  @if not variable-exists('px-only') or not $px-only {
+    // No conversion needed
+    @return $values;
+  }
+
+  @each $value in $values {
+    @if type-of($value) == 'number' and $value != 0 {
+      $unit: unit($value);
+      $scalar: u-parse-int($value);
+
+      @if $unit == 'rem' {
+        $converted: append($converted, u-scale-to-px($scalar));
+      } @else {
+        $converted: append($converted, $value);
+      }
+
+    } @else {
+      $converted: append($converted, $value);
+    }
+  }
+
+  @return $converted;
+}

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -1,9 +1,9 @@
 // Grid
 
 // Neat Breakpoints
-$medium-screen: em(640);
-$large-screen: em(860);
-$x-large-screen: em(1088);
+$medium-screen: em(640) !default;
+$large-screen: em(860) !default;
+$x-large-screen: em(1088) !default;
 
 $med: new-breakpoint(min-width $medium-screen 12);
 $lg: new-breakpoint(min-width $large-screen 12);

--- a/scss/components/_accordions.scss
+++ b/scss/components/_accordions.scss
@@ -9,15 +9,15 @@
 
 .accordion__button {
   @include u-icon-bg($plus-circle, $primary);
-  background-size: 2rem;
+  background-size: u(2rem);
   background-position: 95% 50%;
   border-bottom: 1px solid $base;
   margin: 0 0 -1px 0;
   color: $base;
-  font-size: 1.6rem;
+  font-size: u(1.6rem);
   font-weight: bold;
   letter-spacing: -.3px;
-  padding: 1rem 4rem 1rem 1rem;
+  padding: u(1rem 4rem 1rem 1rem);
   text-align: left;
   width: 100%;
 
@@ -29,7 +29,7 @@
 
 .accordion__content {
   border-bottom: 1px solid $base;
-  padding: 1rem;
+  padding: u(1rem);
 }
 
 .accordion--neutral {

--- a/scss/components/_billboards.scss
+++ b/scss/components/_billboards.scss
@@ -7,11 +7,11 @@
 // Styleguide components.billboards
 
 .billboard {
-  padding: 3rem 0;
+  padding: u(3rem 0);
 }
 
 .billboard__image {
-  max-width: 10rem;
+  max-width: u(10rem);
 }
 
 .billboard__content {
@@ -24,7 +24,7 @@
     }
 
     .billboard__image {
-      max-width: 19rem;
+      max-width: u(19rem);
     }
 
     .billboard__content {

--- a/scss/components/_breadcrumbs.scss
+++ b/scss/components/_breadcrumbs.scss
@@ -39,8 +39,8 @@
   .breadcrumbs__item {
     @include u-truncate();
     float: left;
-    max-width: 20rem;
-    padding: .8rem 0;
+    max-width: u(20rem);
+    padding: u(.8rem 0);
   }
 
   .breadcrumbs__item--current {
@@ -52,6 +52,6 @@
   }
 
   .breadcrumbs__separator {
-    padding: .5rem .8rem;
+    padding: u(.5rem .8rem);
   }
 }

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -24,9 +24,9 @@
   color: $primary;
   display: inline-block;
   font-family: $sans-serif;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   line-height: 1;
-  padding: 8px 2rem;
+  padding: u(8px 2rem);
   text-align: center;
   vertical-align: middle;
 
@@ -36,7 +36,7 @@
   }
 
   &.form-element--inline {
-    min-height: 3.6rem;
+    min-height: u(3.6rem);
   }
 }
 
@@ -220,17 +220,17 @@
   border: 2px solid transparent;
   border-radius: 4px;
   font-family: $sans-serif;
-  font-size: 1.6rem;
-  padding: 1.4rem 3rem;
+  font-size: u(1.6rem);
+  padding: u(1.4rem 3rem);
 }
 
 .button--sm {
   border: 1px solid transparent;
   border-radius: 2px;
   font-family: $sans-serif;
-  font-size: 1.2rem;
+  font-size: u(1.2rem);
   line-height: 1;
-  padding: 5px 1rem;
+  padding: u(5px 1rem);
 
   &:active {
     border: 1px solid;
@@ -255,15 +255,15 @@
   background-position: center center;
   border: none;
   display: none;
-  height: 4rem;
-  padding: .6rem;
+  height: u(4rem);
+  padding: u(.6rem);
   position: absolute;
   top: 0;
   right: 0;
-  width: 4rem;
+  width: u(4rem);
 
   &:hover {
-    padding: .6rem;
+    padding: u(.6rem);
     text-decoration: none;
   }
 
@@ -276,7 +276,7 @@
   position: relative;
 
   input[type="text"] {
-    padding-right: 5rem;
+    padding-right: u(5rem);
   }
 
   &.is-active {
@@ -300,7 +300,7 @@
 
 .button--search {
   @include u-icon-button($magnifying-glass);
-  background-size: 2.2rem;
+  background-size: u(2.2rem);
   background-position: 50%;
   padding: 0;
 }
@@ -318,19 +318,19 @@
 
 .button--calendar {
   @include u-icon-bg($cal-add, $base);
-  background-position: 1rem .7rem;
-  background-size: 2rem;
-  padding-left: 4rem;
-  padding-right: 6rem;
+  background-position: u(1rem .7rem);
+  background-size: u(2rem);
+  padding-left: u(4rem);
+  padding-right: u(6rem);
 }
 
 
 .button--calendar--mini {
   @include u-icon-bg($cal-add, $base);
-  background-position: 1rem .7rem;
-  background-size: 2rem;
-  max-width: 7.4rem;
-  padding-left: 5rem;
+  background-position: u(1rem .7rem);
+  background-size: u(2rem);
+  max-width: u(7.4rem);
+  padding-left: u(5rem);
 }
 
 // Buttons: Icon and text buttons
@@ -395,14 +395,14 @@
 
 .button--cal {
   @include u-icon-button($calendar, left);
-  height: 3.4rem;
-  width: 9rem;
+  height: u(3.4rem);
+  width: u(9rem);
 }
 
 .button--list {
   @include u-icon-button($list, left);
-  height: 3.4rem;
-  width: 9rem;
+  height: u(3.4rem);
+  width: u(9rem);
 }
 
 .button--search--text {
@@ -449,7 +449,7 @@
 
 .button--close--primary {
   @include u-icon($x, $primary);
-  background-size: 2rem;
+  background-size: u(2rem);
   border: none;
 }
 

--- a/scss/components/_callouts.scss
+++ b/scss/components/_callouts.scss
@@ -28,8 +28,8 @@
 
 .callout {
   @include clearfix();
-  padding: 1rem 1.5rem;
-  margin-bottom: 2rem;
+  padding: u(1rem 1.5rem);
+  margin-bottom: u(2rem);
   border-radius: 4px;
 }
 
@@ -47,16 +47,16 @@
 
 .callout__title {
   font-weight: bold;
-  margin: 0 0 .5rem 0;
+  margin: u(0 0 .5rem 0);
 }
 
 .callout__subtitle {
   font-family: $sans-serif;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
 }
 
 .callout__action {
-  padding-top: 1rem;
+  padding-top: u(1rem);
 }
 
 .callout__sublinks {
@@ -73,7 +73,7 @@
   .callout__action {
     @include span-columns(2 of 6);
     border-left: 1px solid;
-    padding-left: 1rem;
+    padding-left: u(1rem);
     padding-top: 0;
   }
 

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -17,8 +17,8 @@
   @include clearfix();
   background-color: $neutral;
   border-radius: 4px;
-  font-size: 1.6rem;
-  padding: 2rem;
+  font-size: u(1.6rem);
+  padding: u(2rem);
   text-align: center;
   width: 100%;
 }
@@ -60,18 +60,18 @@
 
 .card__content {
   text-align: left;
-  padding: 2rem 0 0 0;
+  padding: u(2rem 0 0 0);
   font-family: $serif;
   font-weight: normal;
 }
 
 .card__content--small {
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
 }
 
 .card--horizontal {
-  font-size: 1.4rem;
-  padding: 1rem 2rem;
+  font-size: u(1.4rem);
+  padding: u(1rem 2rem);
   text-align: left;
 
   .card__image {
@@ -107,7 +107,7 @@
     }
 
     .card__content {
-      padding: 1rem 2rem 1rem 0;
+      padding: u(1rem 2rem 1rem 0);
     }
   }
 }
@@ -123,19 +123,19 @@
     @include clearfix();
     background-color: $primary;
     border-radius: 4px 4px 0 0;
-    padding: 1rem;
+    padding: u(1rem);
     text-align: center;
 
     .card__title {
       float: left;
       color: $primary-contrast;
-      padding: 1rem;
+      padding: u(1rem);
       margin: 0;
     }
   }
 
   .card__content {
-    padding: 2rem;
+    padding: u(2rem);
 
     .card__title {
       display: none;
@@ -143,19 +143,19 @@
   }
 
   .icon--complex {
-    max-height: 4rem;
-    max-width: 4rem;
+    max-height: u(4rem);
+    max-width: u(4rem);
     display: block;
     float: left;
   }
 
   @include media($lg) {
-    min-height: 26rem;
+    min-height: u(26rem);
 
     .card__image__container {
       @include span-columns(2 of 6);
       border-radius: 4px 0 0 4px;
-      padding: 9rem 2rem;
+      padding: u(9rem 2rem);
 
       .card__title {
         display: none;
@@ -173,8 +173,8 @@
     }
 
     .icon--complex {
-      max-height: 10rem;
-      max-width: 10rem;
+      max-height: u(10rem);
+      max-width: u(10rem);
       display: inline;
       float: none;
     }
@@ -186,5 +186,5 @@
   letter-spacing: -.3px;
   font-family: $sans-serif;
   font-weight: normal;
-  margin-bottom: 2rem;
+  margin-bottom: u(2rem);
 }

--- a/scss/components/_charts.scss
+++ b/scss/components/_charts.scss
@@ -10,11 +10,11 @@ $tooltip-border-color: #999;
   font-family: $sans-serif;
 
   .chart-series {
-    margin: 1rem;
+    margin: u(1rem);
   }
 
   & + .chart-container {
-    margin-top: 4rem;
+    margin-top: u(4rem);
   }
 }
 
@@ -167,7 +167,7 @@ $tooltip-border-color: #999;
 }
 
 .chart-series__group__label {
-  font-size: 1rem;
+  font-size: u(1rem);
   position: absolute;
   top: 100%;
   left: 0;
@@ -176,7 +176,7 @@ $tooltip-border-color: #999;
   text-align: center;
 
   @include media($med) {
-    font-size: 1.2rem;
+    font-size: u(1.2rem);
   }
 }
 
@@ -276,10 +276,10 @@ $tooltip-border-color: #999;
   .swatch {
     border-radius: 20px;
     display: inline-block;
-    height: 2rem;
-    margin-right: 1rem;
+    height: u(2rem);
+    margin-right: u(1rem);
     padding: 0;
-    width: 2rem;
+    width: u(2rem);
     vertical-align: middle;
   }
 
@@ -289,7 +289,7 @@ $tooltip-border-color: #999;
 }
 
 .chart__key__item {
-  margin-left: 2rem;
+  margin-left: u(2rem);
   float: none;
 
   @include media($med) {

--- a/scss/components/_contact-items.scss
+++ b/scss/components/_contact-items.scss
@@ -28,7 +28,7 @@
 
 .contact-item {
   @include clearfix();
-  margin-bottom: 4rem;
+  margin-bottom: u(4rem);
 }
 
 .contact-item--half {
@@ -42,12 +42,12 @@
 }
 
 .contact-item__title {
-  margin-bottom: .5rem;
+  margin-bottom: u(.5rem);
 }
 
 .contact-item__icon {
   float: left;
-  margin-right: 2rem;
+  margin-right: u(2rem);
 }
 
 .contact-item__content {
@@ -55,10 +55,10 @@
 }
 
 .contact-item__content--offset {
-  margin-left: 5.4rem;
+  margin-left: u(5.4rem);
 }
 
 .contact-item__phone {
   display: block;
-  padding-top: 1rem;
+  padding-top: u(1rem);
 }

--- a/scss/components/_cycle-select.scss
+++ b/scss/components/_cycle-select.scss
@@ -25,7 +25,7 @@
     clear: both;
 
     .button {
-      padding: .9rem 1rem;
+      padding: u(.9rem 1rem);
     }
   }
 }

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -16,7 +16,7 @@
 .dropdown__button {
   position: relative;
   text-align: left;
-  min-height: 3.4rem;
+  min-height: u(3.4rem);
   width: 100%;
 
   &::after {
@@ -28,10 +28,10 @@
     border-left: 1px solid $primary;
     content: '';
     display: block;
-    padding: 1rem 2rem 1rem 1rem;
+    padding: u(1rem 2rem 1rem 1rem);
     position: absolute;
-    right: 1.5rem;
-    top: .5rem;
+    right: u(1.5rem);
+    top: u(.5rem);
   }
 
   &.button--alt-primary::after,
@@ -44,8 +44,8 @@
 
 .dropdown__button--mini {
   &::after {
-    padding: 1rem .5rem 1rem 1.5rem;
-    right: .5rem;
+    padding: u(1rem .5rem 1rem 1.5rem);
+    right: u(.5rem);
   }
 
   & + .dropdown__panel {
@@ -64,10 +64,10 @@
   border: 2px solid $gray-dark;
   border-top: none;
   margin-top: -1px;
-  max-height: 30rem;
+  max-height: u(30rem);
   overflow: hidden;
   text-align: left;
-  top: 3.4rem;
+  top: u(3.4rem);
   z-index: 999;
 
   .dropdown__value,
@@ -76,7 +76,7 @@
     border-bottom: 1px solid $gray-dark;
     display: block;
     margin: 0;
-    padding: .5rem 1rem;
+    padding: u(.5rem 1rem);
     white-space: nowrap;
 
     &:hover {
@@ -97,7 +97,7 @@
 
   // For labeling a group of options
   .dropdown__subhead {
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
     font-weight: bold;
 
     &:hover {
@@ -120,7 +120,7 @@
 }
 
 .dropdown__selected {
-  margin-bottom: .5rem;
+  margin-bottom: u(.5rem);
 
   .dropdown__item {
     @include animation(fadeIn .2s ease-in);

--- a/scss/components/_features.scss
+++ b/scss/components/_features.scss
@@ -34,7 +34,7 @@
 
 .feature {
   font-family: $sans-serif;
-  padding-top: 2rem;
+  padding-top: u(2rem);
 
   p {
     letter-spacing: -.3px;
@@ -44,18 +44,18 @@
 .feature__title {
   @include heading(h1);
   border-bottom: none;
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .feature--bulleted {
   display: list-item;
   list-style-type: disc;
-  padding: 0 2rem 0 0;
+  padding: u(0 2rem 0 0);
 }
 
 .feature-list {
   @include clearfix();
-  padding-left: 2rem;
+  padding-left: u(2rem);
 }
 
 // BREAKPOINT: MEDIUM
@@ -64,8 +64,8 @@
 @include media($med) {
   .feature {
     .card {
-      margin-bottom: 2rem;
-      min-height: 19.5rem;
+      margin-bottom: u(2rem);
+      min-height: u(19.5rem);
     }
   }
 
@@ -76,7 +76,7 @@
   }
 
   .feature--no-title {
-    padding-top: 6.2rem;
+    padding-top: u(6.2rem);
   }
 
   &.feature--bulleted {
@@ -97,17 +97,17 @@
     }
 
     .card {
-      min-height: 34rem;
+      min-height: u(34rem);
     }
 
     .card__image {
-      margin-top: 2rem;
-      width: 12rem;
+      margin-top: u(2rem);
+      width: u(12rem);
     }
   }
 
   .feature--no-title {
-    padding-top: 4.2rem;
+    padding-top: u(4.2rem);
   }
 
   &.feature--bulleted {

--- a/scss/components/_form-styles.scss
+++ b/scss/components/_form-styles.scss
@@ -74,7 +74,7 @@
   option {
     background-color: $neutral;
     color: $primary;
-    padding: .5rem;
+    padding: u(.5rem);
   }
 }
 
@@ -104,7 +104,7 @@
   option {
     background-color: $neutral;
     color: $primary;
-    padding: .5rem;
+    padding: u(.5rem);
   }
 }
 
@@ -122,9 +122,9 @@
   color: inherit;
   display: block;
   font-family: $sans-serif;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   font-weight: bold;
-  margin-bottom: .5rem;
+  margin-bottom: u(.5rem);
   padding: 0;
   text-transform: uppercase;
 }
@@ -133,7 +133,7 @@
   display: block;
   font-family: $sans-serif;
   font-style: italic;
-  margin-bottom: .5rem;
+  margin-bottom: u(.5rem);
 }
 
 // Combo
@@ -158,18 +158,18 @@
   @include clearfix();
 
   .combo__input {
-    height: 3.6rem;
+    height: u(3.6rem);
   }
 
   .combo__button {
-    height: 3.6rem;
-    margin-top: 1rem;
+    height: u(3.6rem);
+    margin-top: u(1rem);
     width: 100%;
   }
 
   @include media($med) {
     .combo__input {
-      height: 3.6rem;
+      height: u(3.6rem);
       border-radius: 2px 0 0 2px;
       float: left;
       width: 80%;
@@ -202,7 +202,7 @@
 
   @include media($med) {
     display: inline;
-    margin: 0 1rem 0 0;
+    margin: u(0 1rem 0 0);
     width: auto;
 
     &:last-child {
@@ -219,5 +219,5 @@
 // Styleguide components.form-styles.date-range-input
 
 .date-range-input {
-  padding-left: 2.5rem;
+  padding-left: u(2.5rem);
 }

--- a/scss/components/_icon-headings.scss
+++ b/scss/components/_icon-headings.scss
@@ -66,56 +66,56 @@
 // Refactor after introducing icon font
 
 @mixin u-icon-heading() {
-  padding-left: 3rem;
+  padding-left: u(3rem);
 }
 
 .icon-heading--profiles {
   @include u-icon-bg($folder-with-person, $inverse);
-  background-size: 2rem;
-  padding-left: 3rem;
+  background-size: u(2rem);
+  padding-left: u(3rem);
 }
 
 .icon-heading--overviews {
   @include u-icon-bg($graph, $inverse);
-  padding-left: 3rem;
+  padding-left: u(3rem);
 }
 
 .icon-heading--location {
   @include u-icon-bg($map-pin, $inverse);
-  padding-left: 3rem;
+  padding-left: u(3rem);
 }
 
 .icon-heading--candidates {
   @include u-icon-bg($candidate, $inverse);
-  background-size: 2rem;
-  padding-left: 3rem;
+  background-size: u(2rem);
+  padding-left: u(3rem);
 }
 
 .icon-heading--committees {
   @include u-icon-bg($committee, $inverse);
-  background-size: 2rem;
-  padding-left: 3rem;
+  background-size: u(2rem);
+  padding-left: u(3rem);
 }
 
 .icon-heading--receipts {
   @include u-icon-bg($piggy-bank, $inverse);
-  background-size: 2rem;
-  padding-left: 3rem;
+  background-size: u(2rem);
+  padding-left: u(3rem);
 }
 
 .icon-heading--disbursements {
   @include u-icon-bg($disbursement, $inverse);
-  background-size: 2rem;
-  padding-left: 3rem;
+  background-size: u(2rem);
+  padding-left: u(3rem);
 }
 
 .icon-heading--filings {
   @include u-icon-bg($papers, $inverse);
-  background-size: 2rem;
-  padding-left: 3rem;
+  background-size: u(2rem);
+  padding-left: u(3rem);
 }
 
 .icon-heading--table {
   @include u-icon-bg($table, $inverse);
-  padding-left: 3rem;
+  padding-left: u(3rem);
 }

--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -9,21 +9,21 @@
 
 .icon {
   display: block;
-  height: 2rem;
-  width: 2rem;
+  height: u(2rem);
+  width: u(2rem);
 }
 
 .icon--complex {
-  max-height: 6rem;
-  max-width: 6rem;
+  max-height: u(6rem);
+  max-width: u(6rem);
 }
 
 .icon--inline--right {
-  margin-left: 1rem;
+  margin-left: u(1rem);
   vertical-align: middle;
 }
 
 .icon--inline--left {
-  margin-right: 1rem;
+  margin-right: u(1rem);
   vertical-align: middle;
 }

--- a/scss/components/_list-styles.scss
+++ b/scss/components/_list-styles.scss
@@ -18,12 +18,12 @@
 .list--bulleted {
   li {
     list-style-type: disc;
-    margin-left: 2rem;
-    padding: .5rem 0;
-    font-size: 1.6rem;
+    margin-left: u(2rem);
+    padding: u(.5rem 0);
+    font-size: u(1.6rem);
 
     &:last-child {
-      margin-bottom: 1.5rem;
+      margin-bottom: u(1.5rem);
     }
   }
 }
@@ -31,7 +31,7 @@
 .list--numbered {
   list-style-type: decimal;
   margin: 0;
-  padding-left: 1rem;
+  padding-left: u(1rem);
 }
 
 .list--flat {
@@ -40,7 +40,7 @@
 
   li {
     float: left;
-    margin-right: 1rem;
+    margin-right: u(1rem);
 
     &:last-child {
       margin-right: 0;
@@ -74,9 +74,9 @@
 .list--checks {
   li {
     @include u-icon-bg($check, $primary);
-    background-size: 2rem;
-    background-position: 0 1.4rem;
-    padding: 1rem 0 1rem 2.5rem;
+    background-size: u(2rem);
+    background-position: u(0 1.4rem);
+    padding: u(1rem 0 1rem 2.5rem);
     position: relative;
   }
 
@@ -107,7 +107,7 @@
 
   li {
     float: left;
-    margin-right: 1rem;
+    margin-right: u(1rem);
     width: 100%;
 
     &:last-child {
@@ -119,7 +119,7 @@
   .button--cta,
   .button--alt {
     display: block;
-    margin-bottom: .5rem;
+    margin-bottom: u(.5rem);
     text-align: left;
     width: 100%;
   }

--- a/scss/components/_maps.scss
+++ b/scss/components/_maps.scss
@@ -1,6 +1,6 @@
 .election-map {
   border: 1px solid $gray;
-  height: 40rem;
+  height: u(40rem);
 
   svg path {
     stroke-width: 1px;
@@ -12,7 +12,7 @@
 }
 
 .state-map {
-  padding-top: 2rem;
+  padding-top: u(2rem);
 
   .button--close {
     float: right;
@@ -20,7 +20,7 @@
 
   .candidate-select {
     float: left;
-    margin-bottom: 1rem;
+    margin-bottom: u(1rem);
   }
 
   @include media($lg) {
@@ -33,7 +33,7 @@
     .button--two-candidates {
       position: absolute;
       right: 0;
-      top: 1rem;
+      top: u(1rem);
     }
   }
 }
@@ -89,11 +89,11 @@ path.shape {
 }
 
 .map-toggles {
-  margin-top: 1rem;
+  margin-top: u(1rem);
 }
 
 .map-panel {
-  padding: 2rem;
+  padding: u(2rem);
   position: relative;
 
   .state-map {

--- a/scss/components/_mega-menu.scss
+++ b/scss/components/_mega-menu.scss
@@ -62,7 +62,7 @@
     margin-bottom: u(1rem);
 
     .mega-heading__title {
-      font-size: 1.6rem;
+      font-size: u(1.6rem);
       line-height: 1.5;
       margin: 0;
       padding-bottom: u(.5rem);

--- a/scss/components/_mega-menu.scss
+++ b/scss/components/_mega-menu.scss
@@ -22,9 +22,9 @@
     visibility: hidden;
 
     &.is-open {
-      top: 4rem;
+      top: u(4rem);
       visibility: visible;
-      padding-bottom: 8rem; // Padding so that the shadow doesn't get cut off
+      padding-bottom: u(8rem); // Padding so that the shadow doesn't get cut off
       z-index: $z-navigation;
 
       .mega__inner {
@@ -46,26 +46,26 @@
     @include transform(translateY(-100%));
     background-color: $primary;
     font-family: $sans-serif;
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
     color: $inverse;
-    padding: 1rem 4rem 2rem 4rem;
+    padding: u(1rem 4rem 2rem 4rem);
   }
 
   .mega-heading {
     border-bottom: 2px solid $inverse;
-    padding-bottom: .8rem;
-    margin: 1rem 0;
+    padding-bottom: u(.8rem);
+    margin: u(1rem 0);
   }
 
   .mega-heading--sub {
     border-bottom: 1px solid $gray-light;
-    margin-bottom: 1rem;
+    margin-bottom: u(1rem);
 
     .mega-heading__title {
       font-size: 1.6rem;
       line-height: 1.5;
       margin: 0;
-      padding-bottom: .5rem;
+      padding-bottom: u(.5rem);
     }
   }
 
@@ -79,7 +79,7 @@
 
   .mega__group {
     @include clearfix();
-    padding-bottom: 2rem;
+    padding-bottom: u(2rem);
   }
 
   .mega__column {
@@ -88,10 +88,10 @@
 
   .mega__item {
     line-height: 1.2;
-    margin-bottom: 1.2rem;
+    margin-bottom: u(1.2rem);
   }
 
   .mega__item__sub {
-    margin-left: 2rem;
+    margin-left: u(2rem);
   }
 }

--- a/scss/components/_messages.scss
+++ b/scss/components/_messages.scss
@@ -23,14 +23,14 @@
 
 .message {
   @include clearfix();
-  background-size: 2rem;
-  background-position: 2rem 2rem;
+  background-size: u(2rem);
+  background-position: u(2rem 2rem);
   background-color: $neutral;
   border-color: $gray;
   border-style: solid;
   border-width: 0 0 0 3px;
-  margin: 2rem 0;
-  padding: 5rem 2rem 2rem 2rem;
+  margin: u(2rem 0);
+  padding: u(5rem 2rem 2rem 2rem);
 }
 
 .message--success {
@@ -52,18 +52,18 @@
 }
 
 .message--no-icon {
-  padding: 2rem;
+  padding: u(2rem);
 }
 
 .message--alert__bottom {
   border-top: 1px solid $gray;
-  margin-top: 1rem;
-  padding-top: 2rem;
+  margin-top: u(1rem);
+  padding-top: u(2rem);
 }
 
 .message__title {
   border-bottom: none;
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .message__content {
@@ -101,9 +101,9 @@
 // Styleguide components.messages.small
 
 .message--small {
-  background-position: 1rem 1rem;
+  background-position: u(1rem 1rem);
   min-height: 0;
-  padding: 4rem 1rem 1rem 1rem;
+  padding: u(4rem 1rem 1rem 1rem);
 }
 
 // Messages: Inverse
@@ -127,7 +127,7 @@
 .message--inverse {
   color: $inverse;
   background-color: rgba($inverse, .1);
-  background-position: 50% 2rem;
+  background-position: u(50% 2rem);
   border-color: $inverse;
 
   &.message--success {
@@ -173,23 +173,23 @@
 
 @include media($med) {
   .message {
-    background-position: 2rem 2rem;
-    background-size: 3rem;
-    min-height: 8rem;
-    padding: 2rem 2rem 2rem 6rem;
+    background-position: u(2rem 2rem);
+    background-size: u(3rem);
+    min-height: u(8rem);
+    padding: u(2rem 2rem 2rem 6rem);
 
     &.message--inverse {
-      background-position: 2rem 2rem;
+      background-position: u(2rem 2rem);
     }
   }
 
   .message--small {
-    background-size: 2rem;
-    background-position: 1rem 1rem;
-    padding: 1rem 1rem 1rem 4rem;
+    background-size: u(2rem);
+    background-position: u(1rem 1rem);
+    padding: u(1rem 1rem 1rem 4rem);
   }
 
   .message--no-icon {
-    padding: 2rem;
+    padding: u(2rem);
   }
 }

--- a/scss/components/_options.scss
+++ b/scss/components/_options.scss
@@ -26,7 +26,7 @@
 .option {
   @include clearfix();
   border-top: 1px solid $primary;
-  padding: 2rem 0;
+  padding: u(2rem 0);
 
   &.option--border-bottom {
     border-bottom: 1px solid $primary;
@@ -35,7 +35,7 @@
 
 .option__aside {
   @include span-columns(4);
-  padding-top: 2rem;
+  padding-top: u(2rem);
 }
 
 @include media($lg) {

--- a/scss/components/_overlay.scss
+++ b/scss/components/_overlay.scss
@@ -14,7 +14,7 @@
 
 .overlay__container {
   position: relative;
-  min-height: 50rem;
+  min-height: u(50rem);
 }
 
 .overlay {

--- a/scss/components/_page-headers.scss
+++ b/scss/components/_page-headers.scss
@@ -17,7 +17,7 @@
 
 .page-header {
   @include clearfix();
-  padding: 1rem;
+  padding: u(1rem);
 
   .search__container {
     display: none;
@@ -32,7 +32,7 @@
 .page-header__icon {
   float: left;
   margin-right: 0;
-  width: 4rem;
+  width: u(4rem);
 }
 
 .page-header--primary {
@@ -46,7 +46,7 @@
 .page-header__title {
   border-bottom: none;
   font-family: $sans-serif;
-  font-size: 1.6rem;
+  font-size: u(1.6rem);
   text-transform: uppercase;
   margin-bottom: 0;
   line-height: 1;
@@ -58,18 +58,18 @@
 
 @include media($med) {
   .page-header {
-    padding: 1rem 2rem;
+    padding: u(1rem 2rem);
 
     .search__container {
       display: block;
       float: right;
-      width: 40rem;
+      width: u(40rem);
     }
   }
 
   .page-header__title {
     float: left;
-    line-height: 4rem;
+    line-height: u(4rem);
   }
 }
 
@@ -79,7 +79,7 @@
 @include media($lg) {
   .page-header {
     .search__container {
-      width: 50rem;
+      width: u(50rem);
     }
   }
 }

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -25,7 +25,7 @@
   @extend .button--sm;
   display: inline-block;
   height: auto;
-  margin-left: .5rem;
+  margin-left: u(.5rem);
 
   &.previous,
   &.next {

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -5,16 +5,16 @@
 .rich-text {
 
   li {
-    font-size: 1.6rem;
+    font-size: u(1.6rem);
   }
 
   ul {
-    margin-bottom: 1rem;
+    margin-bottom: u(1rem);
 
     li {
       list-style-type: disc;
-      margin-left: 2rem;
-      padding: 0 0 .5rem 0;
+      margin-left: u(2rem);
+      padding: u(0 0 .5rem 0);
       margin-bottom: 0;
 
       // Hack because the editor is putting all text in <p>s
@@ -28,7 +28,7 @@
     li {
       list-style-type: decimal;
       margin: 0;
-      padding-left: 1rem;
+      padding-left: u(1rem);
     }
   }
 

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -25,8 +25,8 @@
 .search__select {
   border-radius: 4px 0 0 4px;
   margin-right: -2px;
-  height: 3.6rem;
-  width: 14rem;
+  height: u(3.6rem);
+  width: u(14rem);
   float: left;
 }
 
@@ -62,8 +62,8 @@
     border-radius: 0 4px 4px 0;
     margin-top: 0;
     float: right;
-    height: 3.6rem;
-    width: 5.6rem;
+    height: u(3.6rem);
+    width: u(5.6rem);
   }
 }
 
@@ -76,7 +76,7 @@
     }
 
     .combo__button {
-      width: 5.6rem;
+      width: u(5.6rem);
     }
 
     .tt-menu {
@@ -85,28 +85,28 @@
   }
 
   .combo--search--large {
-    height: 6rem;
+    height: u(6rem);
 
     .combo__input {
-      font-size: 1.8rem;
-      height: 6rem;
+      font-size: u(1.8rem);
+      height: u(6rem);
       line-height: 1;
       width: calc(100% - 26rem);
     }
 
     .combo__button {
-      height: 6rem;
-      width: 10rem;
+      height: u(6rem);
+      width: u(10rem);
     }
 
     .search__select {
-      height: 6rem;
-      width: 16rem;
-      font-size: 1.8rem;
+      height: u(6rem);
+      width: u(16rem);
+      font-size: u(1.8rem);
     }
 
     .tt-menu {
-      font-size: 1.6rem;
+      font-size: u(1.6rem);
       top: 5.9rem !important;
       width: calc(100% - 10.2rem);
     }
@@ -127,7 +127,7 @@
   background-color: $inverse;
   border: 1px solid $primary;
   font-family: $sans-serif;
-  font-size: 1.2rem;
+  font-size: u(1.2rem);
   left: 0;
   position: absolute;
   text-align: left;
@@ -138,7 +138,7 @@
 .tt-suggestion {
   display: table;
   position: relative;
-  padding: 1rem;
+  padding: u(1rem);
   margin-bottom: 0;
   line-height: 1;
   border-top: 1px solid $gray-lightest;
@@ -156,7 +156,7 @@
 
 .tt-suggestion__office.tt-suggestion__office {
   color: $base;
-  font-size: 1.2rem;
+  font-size: u(1.2rem);
   text-align: right;
   font-style: italic;
 }
@@ -180,14 +180,14 @@
   color: $base;
   display: block;
   font-weight: bold;
-  padding: 1rem .5rem;
+  padding: u(1rem .5rem);
 }
 
 .tt-suggestion__loading.tt-suggestion__loading {
   color: $primary;
   display: block;
   font-weight: bold;
-  padding: 1rem .5rem;
+  padding: u(1rem .5rem);
 }
 
 .tt-dataset-0 {
@@ -199,7 +199,7 @@
 .js-typeahead-filter {
   .button--search {
     @include u-icon-button($magnifying-glass-arrow);
-    background-size: 2.8rem;
+    background-size: u(2.8rem);
     background-position: 50%;
     padding: 0;
   }
@@ -211,7 +211,7 @@
 
     .button--search {
       @include u-icon-button($magnifying-glass);
-      background-size: 2.2rem;
+      background-size: u(2.2rem);
       background-position: 50%;
       padding: 0;
     }

--- a/scss/components/_search-results.scss
+++ b/scss/components/_search-results.scss
@@ -14,7 +14,7 @@
 // Styleguide components.search-results.title
 
 .results__title {
-  margin: 2rem 0 1rem 0;
+  margin: u(2rem 0 1rem 0);
 }
 
 // Search results: Count
@@ -30,7 +30,7 @@
 // Styleguide components.search-results.count
 
 .results__count {
-  padding: 2rem 0;
+  padding: u(2rem 0);
 }
 
 // Search results: Name search result
@@ -74,12 +74,12 @@
 .result__years {
   display: block;
   font-weight: bold;
-  margin-bottom: 1.5rem;
+  margin-bottom: u(1.5rem);
 }
 
 .result {
   border-top: 2px solid $gray;
-  padding: 2rem 0;
+  padding: u(2rem 0);
 
   &:first-of-type {
     border-top: none;
@@ -101,7 +101,7 @@
 }
 
 .result__related {
-  padding: 1rem 0;
+  padding: u(1rem 0);
 }
 
 // Search results: Election result
@@ -166,7 +166,7 @@
 
 @include media($lg) {
   .result {
-    padding: 3rem 0;
+    padding: u(3rem 0);
   }
 
   .result__title {

--- a/scss/components/_side-nav.scss
+++ b/scss/components/_side-nav.scss
@@ -21,7 +21,7 @@
 }
 
 .side-nav__item {
-  padding: 1rem 0;
+  padding: u(1rem 0);
 
   &:first-child {
     padding-top: 0;

--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -41,26 +41,26 @@
 
   &.is-fixed {
     position: fixed;
-    top: 2rem;
+    top: u(2rem);
     left: auto;
   }
 }
 
 .sidebar__title {
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   font-weight: bold;
   margin: 0;
-  padding: 1rem 2rem;
+  padding: u(1rem 2rem);
   text-transform: uppercase;
 }
 
 .sidebar__content {
   @include clearfix();
   background-color: $neutral;
-  padding: 2rem;
+  padding: u(2rem);
 
   p {
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
     color: $base;
   }
 }

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -30,19 +30,19 @@
   border-width: 2px 0;
   color: $primary;
   font-family: $sans-serif;
-  margin: 2rem 0;
+  margin: u(2rem 0);
 }
 
 .simple-table__header {
   border-bottom: 1px solid $primary;
 
   th {
-    padding: .5rem 0;
+    padding: u(.5rem 0);
   }
 }
 
 .simple-table__cell {
-  padding: 1rem 0;
+  padding: u(1rem 0);
   border-bottom: 1px solid $neutral;
   vertical-align: top;
 
@@ -63,5 +63,5 @@
 // This closes that gap
 
 h3 + .simple-table {
-  margin-top: -1rem;
+  margin-top: u(-1rem);
 }

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -6,13 +6,13 @@
   float: left;
   color: $primary-contrast;
   margin: 0;
-  padding: .5rem 1rem .5rem 0;
+  padding: u(.5rem 1rem .5rem 0);
 }
 
 .tags__title__text {
   color: $inverse;
   display: inline-block;
-  margin: 4px .5rem;
+  margin: u(4px .5rem);
 }
 
 .tags {
@@ -27,13 +27,13 @@
   font-family: $sans-serif;
   letter-spacing: -.3px;
   margin: 0 4px 2px 0;
-  padding: 2px .75rem;
+  padding: u(2px .75rem);
 }
 
 .tag__remove {
   @include u-icon-bg($x, $primary);
-  background-size: 1.4rem;
+  background-size: u(1.4rem);
   background-position: 100% 45%;
   border: none;
-  padding: 1rem;
+  padding: u(1rem);
 }

--- a/scss/components/_toggles.scss
+++ b/scss/components/_toggles.scss
@@ -104,7 +104,7 @@
 
   .label {
     float: left;
-    margin: .5rem 1rem 0 0;
+    margin: u(.5rem 1rem 0 0);
   }
 
   .button--alt,
@@ -137,9 +137,9 @@
   .toggle {
     border-bottom: 1px dotted $primary;
     color: $primary;
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
     padding: 0;
-    margin: 0 1rem;
+    margin: u(0 1rem);
   }
 
   .is-active {

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -23,7 +23,7 @@
   background-color: $inverse;
   color: $primary;
   font-family: $sans-serif;
-  padding: 1.5rem;
+  padding: u(1.5rem);
   position: absolute;
   text-align: center;
   z-index: $z-tooltip;
@@ -39,7 +39,7 @@
 .tooltip__content.tooltip__content { // Hack to override any font color styles on the parent element
   color: $primary;
   text-align: left;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   font-weight: normal;
   line-height: 1.4;
   margin-bottom: 0;
@@ -51,14 +51,14 @@
 }
 
 .tooltip--above {
-  width: 12rem;
+  width: u(12rem);
 
   &::before {
     @include triangle(2rem, $primary, down);
-    bottom: -1rem;
+    bottom: u(-1rem);
     content: '';
     display: block;
-    left: 5rem;
+    left: u(5rem);
     position: absolute;
   }
 
@@ -67,21 +67,21 @@
     content: '';
     display: block;
     position: absolute;
-    left: 5.2rem;
-    bottom: -.7rem;
+    left: u(5.2rem);
+    bottom: u(-.7rem);
   }
 }
 
 .tooltip--under {
-  max-width: 30rem;
+  max-width: u(30rem);
 
   &::before {
     @include triangle(2rem, $primary, up);
     content: '';
     display: block;
     position: absolute;
-    left: 4rem;
-    top: -1rem;
+    left: u(4rem);
+    top: u(-1rem);
   }
 
   &::after {
@@ -89,8 +89,8 @@
     content: '';
     display: block;
     position: absolute;
-    left: 4.2rem;
-    top: -.7rem;
+    left: u(4.2rem);
+    top: u(-.7rem);
   }
 }
 
@@ -156,12 +156,12 @@
   }
 
   .tooltip__title {
-    line-height: 4rem;
-    padding-left: 1rem;
+    line-height: u(4rem);
+    padding-left: u(1rem);
     float: left;
   }
 
   .tooltip__content {
-    padding: 1rem;
+    padding: u(1rem);
   }
 }

--- a/scss/components/_type-styles.scss
+++ b/scss/components/_type-styles.scss
@@ -58,12 +58,12 @@
   @include clearfix();
   border-bottom: 1px solid $base;
   border-top: 1px solid $base;
-  padding: 1rem 0;
+  padding: u(1rem 0);
 }
 
 .t-ruled--bottom {
   border-bottom: 1px solid $base;
-  padding-bottom: 1rem;
+  padding-bottom: u(1rem);
 }
 
 .t-ruled--bold {
@@ -116,7 +116,7 @@
   font-family: $serif;
   font-weight: normal;
   font-style: italic;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
 }
 
 .t-block {
@@ -170,8 +170,8 @@
   display: block;
   color: $base;
   font-family: $sans-serif;
-  font-size: 3.6rem;
-  margin-bottom: 1rem;
+  font-size: u(3.6rem);
+  margin-bottom: u(1rem);
 }
 
 .t-secondary-contrast.t-secondary-contrast {
@@ -180,8 +180,8 @@
 
 .t-lead {
   font-weight: regular;
-  font-size: 1.8rem;
-  line-height: 2.8rem;
+  font-size: u(1.8rem);
+  line-height: u(2.8rem);
 }
 
 .t-short {

--- a/scss/components/_widgets.scss
+++ b/scss/components/_widgets.scss
@@ -5,22 +5,22 @@
 // Styleguide component.widgets
 
 .widget {
-  padding: 1rem;
+  padding: u(1rem);
 
   &:nth-child(2) {
     border-top: 1px solid $gray;
-    padding-top: 2rem;
+    padding-top: u(2rem);
   }
 }
 
 .widget__title {
   border-bottom: 2px solid;
   margin-bottom: 0;
-  padding-bottom: 1rem;
+  padding-bottom: u(1rem);
 }
 
 .widget__content {
-  padding: 2rem 0;
+  padding: u(2rem 0);
 }
 
 .widget--neutral {
@@ -35,15 +35,15 @@
   .widget {
     width: 50%;
     float: left;
-    padding: 3rem;
+    padding: u(3rem);
   }
 
   .widget:nth-child(2) {
     border-top: none;
-    padding-top: 3rem;
+    padding-top: u(3rem);
   }
 
   .widget__content {
-    padding: 3rem 0 0 0;
+    padding: u(3rem 0 0 0);
   }
 }

--- a/scss/elements/_forms.scss
+++ b/scss/elements/_forms.scss
@@ -49,11 +49,11 @@ select {
   border-style: solid;
   border-radius: 4px;
   font-family: $sans-serif;
-  font-size: 1.4rem;
-  height: 3.6rem;
-  line-height: 1.4rem;
+  font-size: u(1.4rem);
+  height: u(3.6rem);
+  line-height: u(1.4rem);
   margin: 0;
-  padding: 1rem;
+  padding: u(1rem);
   transition: border-color;
   width: 100%;
 
@@ -74,7 +74,7 @@ select {
   background-size: 12px;
   color: $base;
   border: 2px solid $gray;
-  padding: .6rem 3rem .6rem 1rem;
+  padding: u(.6rem 3rem .6rem 1rem);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -97,7 +97,7 @@ input[type="search"] {
 }
 
 input[type="file"] {
-  padding-bottom: 1rem;
+  padding-bottom: u(1rem);
   width: 100%;
 }
 
@@ -154,9 +154,9 @@ input[type="file"] {
   background-color: $gray;
   display: inline-block;
   cursor: pointer;
-  line-height: 2rem;
-  margin: 0 0 1rem .25rem;
-  padding: .4rem .8rem .4rem 3rem;
+  line-height: u(2rem);
+  margin: u(0 0 1rem .25rem);
+  padding: u(.4rem .8rem .4rem 3rem);
 
   &:hover {
     background-color: $gray-medium;
@@ -169,19 +169,19 @@ input[type="file"] {
     border-radius: 2px;
     content: '';
     display: inline-block;
-    height: 1.6rem;
+    height: u(1.6rem);
     margin-right: .6em;
-    margin-left: -2.4rem;
+    margin-left: u(-2.4rem);
     text-indent: .15em;
-    width: 1.6rem;
+    width: u(1.6rem);
     vertical-align: -4px;
   }
 }
 
 [type="radio"] + label::before {
-  height: 1.6rem;
-  width: 1.6rem;
-  border-radius: 1.6rem;
+  height: u(1.6rem);
+  width: u(1.6rem);
+  border-radius: u(1.6rem);
 }
 
 [type="checkbox"]:checked + label,

--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -24,11 +24,11 @@ ol {
 }
 
 dl {
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 
   dt {
     font-weight: bold;
-    margin-top: 1rem;
+    margin-top: u(1rem);
   }
 
   dd {

--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -20,7 +20,7 @@ body {
   // -webkit-font-smoothing: antialiased;
   color: $base;
   font-family: $base-font-family;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   line-height: 1.5;
 }
 
@@ -50,25 +50,25 @@ h6 {
 
 p {
   color: inherit;
-  font-size: 1.6rem;
-  margin: 0 0 1rem 0;
-  max-width: 80rem;
+  font-size: u(1.6rem);
+  margin: u(0 0 1rem 0);
+  max-width: u(80rem);
   width: 100%;
 
   & + h1 {
-    margin-top: 3rem;
+    margin-top: u(3rem);
   }
 
   & + h2 {
-    margin-top: 3rem;
+    margin-top: u(3rem);
   }
 
   & + h3 {
-    margin-top: 2rem;
+    margin-top: u(2rem);
   }
 
   & + h4 {
-    margin-top: 2rem;
+    margin-top: u(2rem);
   }
 }
 
@@ -77,7 +77,7 @@ hr {
   border-left: none;
   border-right: none;
   border-top: none;
-  margin: 1rem 0;
+  margin: u(1rem 0);
 }
 
 

--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -29,7 +29,7 @@
 }
 
 .grid__item {
-  margin-bottom: 2rem;
+  margin-bottom: u(2rem);
   width: 100%;
 }
 

--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -26,7 +26,7 @@
 
 .container {
   @include outer-container();
-  padding: 0 2rem;
+  padding: u(0 2rem);
 
   @include media($lg) {
     padding: 0;
@@ -39,19 +39,19 @@
 
 .main {
   @include clearfix();
-  padding-bottom: 2rem;
-  padding-top: 2rem;
+  padding-bottom: u(2rem);
+  padding-top: u(2rem);
   position: relative;
 
   @include media($lg) {
-    padding-top: 4rem;
-    padding-bottom: 4rem;
+    padding-top: u(4rem);
+    padding-bottom: u(4rem);
   }
 }
 
 .content--blank {
   border-top: 1px solid $neutral;
-  padding: 4rem 0;
+  padding: u(4rem 0);
 }
 
 .main__content {
@@ -75,7 +75,7 @@
 .main__title {
   @include heading(display);
   border-bottom: 2px solid $primary;
-  margin-bottom: 3rem;
+  margin-bottom: u(3rem);
 }
 
 .main__content--full {
@@ -85,25 +85,25 @@
 
 .content__section {
   @include clearfix();
-  padding: 0 0 2rem 0;
+  padding: u(0 0 2rem 0);
 }
 
 .content__section--extra {
   @include clearfix();
-  padding: 2rem 0;
+  padding: u(2rem 0);
 
   @include media($lg) {
-    padding: 4rem 0;
+    padding: u(4rem 0);
   }
 }
 
 .content__section--ruled {
   border-top: 1px solid $primary;
-  margin-top: 2rem;
-  padding-top: 2rem;
+  margin-top: u(2rem);
+  padding-top: u(2rem);
 
   &.content__section--extra {
-    padding-top: 4rem;
+    padding-top: u(4rem);
   }
 
   & + .content__section--ruled {
@@ -114,19 +114,19 @@
 // Utility padding classes
 
 .u-padding--top {
-  padding-top: 2rem;
+  padding-top: u(2rem);
 }
 
 .u-padding--bottom {
-  padding-bottom: 2rem;
+  padding-bottom: u(2rem);
 }
 
 .u-padding-left {
-  padding-left: 2rem;
+  padding-left: u(2rem);
 }
 
 .u-padding--right {
-  padding-right: 2rem;
+  padding-right: u(2rem);
 }
 
 // Class applied to candidate and committee pages with tabs

--- a/scss/layout/_slabs.scss
+++ b/scss/layout/_slabs.scss
@@ -19,7 +19,7 @@
 
 .slab {
   @include clearfix();
-  padding: 2rem 0;
+  padding: u(2rem 0);
 }
 
 .slab--primary {

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -6,68 +6,68 @@
   @if $level == display {
     border-bottom: 0;
     font-family: $serif;
-    font-size: 3.6rem;
+    font-size: u(3.6rem);
     font-weight: bold;
     line-height: 1;
-    margin: 0 0 1rem 0;
-    padding: 1.2rem 0;
+    margin: u(0 0 1rem 0);
+    padding: u(1.2rem 0);
 
     @include media($med) {
-      font-size: 4.8rem;
+      font-size: u(4.8rem);
     }
   }
 
   @if $level == h1 {
     border-bottom: 1px solid $base;
     font-family: $serif;
-    font-size: 2.4rem;
+    font-size: u(2.4rem);
     font-weight: bold;
     line-height: 1.15;
 
     @include media($med) {
-      font-size: 3rem;
+      font-size: u(3rem);
     }
   }
 
   @if $level == h2 {
     font-family: $serif;
-    font-size: 2rem;
+    font-size: u(2rem);
     font-weight: bold;
     line-height: 1.2;
 
     @include media($med) {
-      font-size: 2.4rem;
+      font-size: u(2.4rem);
     }
   }
 
   @if $level == h3 {
     font-family: $serif;
-    font-size: 1.8rem;
+    font-size: u(1.8rem);
     font-weight: bold;
     line-height: 1.14;
   }
 
   @if $level == h4 {
     font-family: $sans-serif;
-    font-size: 1.8rem;
+    font-size: u(1.8rem);
     font-weight: normal;
-    margin: 2rem 0 .5rem 0;
+    margin: u(2rem 0 .5rem 0);
     line-height: 1.2;
     letter-spacing: -.3px;
   }
 
   @if $level == h5 {
     font-family: $serif;
-    font-size: 1.6rem;
+    font-size: u(1.6rem);
     font-weight: bold;
-    margin: 1.5rem 0 .75rem 0;
+    margin: u(1.5rem 0 .75rem 0);
     line-height: 1.33;
   }
 
   @if $level == h6 {
     border-bottom: 1px solid $base;
     font-family: $sans-serif;
-    font-size: 1.3rem;
+    font-size: u(1.3rem);
     font-weight: normal;
     line-height: 1.63;
     text-transform: uppercase;

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -49,7 +49,7 @@
 .u-blank-space {
   display: inline-block;
   border-bottom: 1px solid $inverse;
-  width: 5rem;
+  width: u(5rem);
 }
 
 // u-icon-bg()
@@ -155,7 +155,7 @@
   option {
     background-color: $neutral;
     color: $base;
-    padding: .5rem;
+    padding: u(.5rem);
   }
 }
 
@@ -324,7 +324,7 @@
   background-size: $width;
 
   @if $side == left {
-    background-position: 1rem 50%;
+    background-position: u(1rem 50%);
     padding-left: $width + 2rem;
   } @else {
     background-position: 90% 50%;

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -1,6 +1,6 @@
 // Utility Mixins
 //
-// Weight: -90
+// Weight: 90
 //
 // Styleguide mixins
 

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -13,7 +13,7 @@
 
   .fc-day {
     font-weight: bold;
-    padding: .7rem 1rem 0 2rem;
+    padding: u(.7rem 1rem 0 2rem);
   }
 }
 
@@ -25,7 +25,7 @@
 .fc-toolbar {
   @include clearfix();
   border-bottom: 2px solid $primary;
-  padding: 2rem 0 1.5rem 0;
+  padding: u(2rem 0 1.5rem 0);
 }
 
 .fc-left {
@@ -33,22 +33,22 @@
 
   .fc-button-group {
     float: left;
-    margin-right: 1rem;
+    margin-right: u(1rem);
   }
 
   .fc-today-button {
-    margin-left: 1rem;
+    margin-left: u(1rem);
   }
 
   .fc-prev-button,
   .fc-next-button {
     margin-right: 1px;
     text-indent: -9999px;
-    padding: .8rem 1rem;
+    padding: u(.8rem 1rem);
 
     &::after {
-      left: .5rem;
-      right: .5rem;
+      left: u(.5rem);
+      right: u(.5rem);
     }
   }
 }
@@ -82,14 +82,14 @@
 .fc-day-header {
   color: $primary;
   font-weight: normal;
-  padding-top: .5rem;
+  padding-top: u(.5rem);
 }
 
 .fc-content-skeleton {
   height: 100%;
 
   table {
-    min-height: 12rem;
+    min-height: u(12rem);
   }
 }
 
@@ -118,7 +118,7 @@
   border-bottom: none;
   color: $primary;
   font-weight: bold;
-  padding: .3rem 1rem;
+  padding: u(.3rem 1rem);
 }
 
 .fc-day-number.fc-today {
@@ -140,7 +140,7 @@
   overflow: hidden;
   background: none;
   color: $primary;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   line-height: 1.2;
   padding: 2px 4px;
   position: relative;
@@ -148,10 +148,10 @@
   &::before {
     content: '';
     display: block;
-    width: .6rem;
-    height: .6rem;
+    width: u(.6rem);
+    height: u(.6rem);
     background-color: $primary;
-    border-radius: .8rem;
+    border-radius: u(.8rem);
     float: left;
     margin: 5px 5px 5px 0;
   }
@@ -164,7 +164,7 @@
     top: 0;
     bottom: 0;
     right: 0;
-    width: 3rem;
+    width: u(3rem);
   }
 }
 
@@ -212,16 +212,16 @@
 
 .cal__category {
   border-radius: 3px;
-  padding: .5rem;
+  padding: u(.5rem);
 }
 
 // Event details
 .cal-details {
-  font-size: 1.4rem;
-  margin-top: 1rem;
+  font-size: u(1.4rem);
+  margin-top: u(1rem);
   padding: 0;
   text-align: left;
-  width: 26rem;
+  width: u(26rem);
   white-space: initial;
 
   .button--close--primary {
@@ -237,12 +237,12 @@
 
     &::before {
       left: auto;
-      right: 1rem;
+      right: u(1rem);
     }
 
     &::after {
       left: auto;
-      right: 1.2rem;
+      right: u(1.2rem);
     }
   }
 }
@@ -250,44 +250,44 @@
 .cal-details__date {
   display: block;
   font-weight: bold;
-  padding-bottom: 1rem;
+  padding-bottom: u(1rem);
 }
 
 .cal-details__title {
   display: block;
   font-weight: bold;
   line-height: 1.4;
-  padding-bottom: .5rem;
+  padding-bottom: u(.5rem);
 }
 
 .cal-details__summary {
   display: block;
   line-height: 1.2;
-  padding-bottom: .5rem;
+  padding-bottom: u(.5rem);
 }
 
 .cal-details__location {
   display: block;
   line-height: 1.2;
-  padding-bottom: .5rem;
+  padding-bottom: u(.5rem);
 }
 
 .cal-details__add {
-  margin-top: 1rem;
+  margin-top: u(1rem);
 }
 
 .fc-popup {
   background: $inverse;
   border: 2px solid $neutral;
   position: absolute;
-  max-width: 20rem;
+  max-width: u(20rem);
 
   .button {
     position: absolute;
     top: 0;
     right: 0;
-    width: 3rem;
-    height: 3rem;
+    width: u(3rem);
+    height: u(3rem);
   }
 }
 
@@ -318,7 +318,7 @@
 
 .fc-slats {
   td {
-    height: 1.5rem;
+    height: u(1.5rem);
   }
 
   tr {
@@ -338,7 +338,7 @@
   }
 
   .fc-axis {
-    padding: .5rem 1rem 0 1rem;
+    padding: u(.5rem 1rem 0 1rem);
     text-align: right;
     vertical-align: middle;
     white-space: nowrap;
@@ -355,17 +355,17 @@
 
 .cal-view__toggles {
   float: right;
-  padding-left: 1rem;
+  padding-left: u(1rem);
 }
 
 // List view
 .cal-list__toggles {
-  padding-top: 2rem;
+  padding-top: u(2rem);
 }
 
 .cal-list {
   letter-spacing: -.3px;
-  padding-top: 2rem;
+  padding-top: u(2rem);
 }
 
 .cal-list__title {
@@ -373,14 +373,14 @@
   border-left: .5rem solid $primary;
   font-family: $sans-serif;
   letter-spacing: 0;
-  margin: 2rem 0 0 0;
-  padding: 1rem;
+  margin: u(2rem 0 0 0);
+  padding: u(1rem);
 }
 
 .cal-list__event {
   @include clearfix();
   border-bottom: 1px solid $neutral;
-  padding: 2rem 0;
+  padding: u(2rem 0);
 
   &:last-child {
     border-bottom: none;
@@ -390,7 +390,7 @@
 
 .cal-list__details {
   @include span-columns(8);
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .cal-list__add {
@@ -413,10 +413,10 @@
 
 .cal-list__description {
   @include span-columns(8 of 8);
-  padding-top: 2rem;
+  padding-top: u(2rem);
 
   p {
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
   }
 }
 
@@ -428,7 +428,7 @@
   display: inline-block;
   border: 1px solid;
   border-color: $primary;
-  padding: 0 .5rem;
+  padding: u(0 .5rem);
   border-radius: 3px;
 }
 
@@ -445,17 +445,17 @@
   background-color: $inverse;
   border: 2px solid $neutral;
   position: absolute;
-  width: 22rem;
+  width: u(22rem);
 
   .fc-header {
     background: $neutral;
-    padding: 3px .5rem;
+    padding: u(3px .5rem);
 
     .fc-title {
       float: left;
       font-weight: bold;
       height: auto;
-      line-height: 2rem;
+      line-height: u(2rem);
       width: auto;
     }
   }
@@ -467,11 +467,11 @@
   }
 
   .fc-event-container {
-    padding: .5rem;
+    padding: u(.5rem);
   }
 
   .fc-content {
-    margin-bottom: .5rem;
+    margin-bottom: u(.5rem);
   }
 }
 
@@ -503,9 +503,9 @@
 
     .button {
       background-position: 50% 50%;
-      padding-left: 2rem;
+      padding-left: u(2rem);
       text-indent: -9999px;
-      width: 4rem;
+      width: u(4rem);
     }
   }
 }
@@ -515,10 +515,10 @@
 
 @include media($lg) {
   .cal-list {
-    font-size: 1.6rem;
+    font-size: u(1.6rem);
 
     p {
-      font-size: 1.6rem;
+      font-size: u(1.6rem);
     }
   }
 
@@ -536,7 +536,7 @@
 
   .cal-list__event {
     @include clearfix();
-    padding: 2rem;
+    padding: u(2rem);
   }
 
   .cal-list__details {
@@ -546,7 +546,7 @@
 
   .cal-list__add {
     @include span-columns(2);
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
   }
 
   .cal-list__date {

--- a/scss/modules/_data-container.scss
+++ b/scss/modules/_data-container.scss
@@ -9,7 +9,7 @@
   border-top: 2px solid $neutral;
   position: relative;
   width: 100%;
-  padding-top: 2rem;
+  padding-top: u(2rem);
 }
 
 .is-showing-filters {
@@ -22,7 +22,7 @@
   background-color: $primary;
   border-top: 1px solid $inverse;
   font-family: $sans-serif;
-  padding: 2rem;
+  padding: u(2rem);
 }
 
 .data-container__widgets--secondary {
@@ -30,7 +30,7 @@
 }
 
 .data-container__body {
-  padding: 0 1rem;
+  padding: u(0 1rem);
 
   &.fade-in {
     opacity: 0;
@@ -42,7 +42,7 @@
 }
 
 .data-container__export {
-  margin-top: 1rem;
+  margin-top: u(1rem);
 }
 
 .export-widget {
@@ -52,7 +52,7 @@
 .panel__controls {
   @include clearfix();
   clear: both;
-  padding-top: .5rem;
+  padding-top: u(.5rem);
 }
 
 
@@ -73,11 +73,11 @@
 
   .data-container__body {
     border-top: 0;
-    padding: 0 2rem 2rem 2rem;
+    padding: u(0 2rem 2rem 2rem);
   }
 
   .data-container__widgets {
-    padding: 1rem 2rem;
+    padding: u(1rem 2rem);
   }
 
   .data-container__export {
@@ -93,7 +93,7 @@
 
   .export-widget {
     float: left;
-    margin-right: 1rem;
+    margin-right: u(1rem);
     width: calc(50% - .5rem);
 
     &:last-of-type {

--- a/scss/modules/_datatable-panel.scss
+++ b/scss/modules/_datatable-panel.scss
@@ -25,7 +25,7 @@
   @include transition(opacity .2s);
   background-color: $inverse;
   overflow: hidden;
-  padding: 1rem;
+  padding: u(1rem);
   float: right;
   width: 50%;
   opacity: 0;
@@ -62,18 +62,18 @@
   background-color: rgba($gray-lightest, .3);
   border: 1px solid $gray-lightest;
   font-family: $sans-serif;
-  padding: 1rem;
+  padding: u(1rem);
 
   td {
-    padding-bottom: 1rem;
+    padding-bottom: u(1rem);
     vertical-align: top;
   }
 }
 
 .panel__heading {
   border-bottom: 1px solid $neutral;
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
+  margin-bottom: u(1rem);
+  padding-bottom: u(1rem);
 
   .panel__title {
     margin-bottom: 0;
@@ -90,7 +90,7 @@
 }
 
 .panel__row {
-  padding: 2rem 0 1rem 0;
+  padding: u(2rem 0 1rem 0);
   border-bottom: 1px solid $neutral;
 
   &:last-child {
@@ -101,7 +101,7 @@
 .panel__term {
   font-weight: bold;
   letter-spacing: -.3px;
-  padding-right: 2rem;
+  padding-right: u(2rem);
   vertical-align: top;
 }
 
@@ -115,7 +115,7 @@
 .panel__navigation {
   @include clearfix();
   border-bottom: 1px solid $gray-lightest;
-  padding: 0 0 1rem 0;
+  padding: u(0 0 1rem 0);
   text-align: right;
 }
 
@@ -126,12 +126,12 @@
 .panel__close {
   @include u-icon-bg($arrow-left-border, $primary);
   background-position: 0 50%;
-  background-size: 1.5rem;
+  background-size: u(1.5rem);
   background-repeat: no-repeat;
   border: none;
   cursor: pointer;
   float: left;
-  padding-left: 3rem;
+  padding-left: u(3rem);
 
   &::after {
     content: "View all";
@@ -178,7 +178,7 @@
   }
 
   .panel__navigation {
-    padding: .6rem 2rem;
+    padding: u(.6rem 2rem);
     text-align: left;
     margin-bottom: 0;
   }
@@ -189,7 +189,7 @@
 
   .panel__close {
     @include u-icon($x, $primary);
-    background-size: 2rem;
+    background-size: u(2rem);
     position: absolute;
     right: 0;
     top: 0;
@@ -205,13 +205,13 @@
     .panel__main {
       left: 0;
       width: 100%;
-      min-height: 150rem;
+      min-height: u(150rem);
       height: auto;
       overflow: visible;
     }
 
     .panel__overlay {
-      min-height: 150rem;
+      min-height: u(150rem);
     }
 
     .data-table {
@@ -225,7 +225,7 @@
   }
 
   .panel__row {
-    padding: 1rem 1.8rem;
+    padding: u(1rem 1.8rem);
     margin-top: 0;
 
     &:last-child {
@@ -247,7 +247,7 @@
 
   td {
     border-bottom: 0;
-    padding: .3rem 0;
+    padding: u(.3rem 0);
     white-space: pre-wrap;
     overflow: visible;
 

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -67,9 +67,9 @@
   position: relative;
 
   th {
-    line-height: 1.4rem;
+    line-height: u(1.4rem);
     letter-spacing: -.3px;
-    padding: .5rem 1rem;
+    padding: u(.5rem 1rem);
     border-bottom: 1px solid $primary;
 
     &.sorting,
@@ -78,22 +78,22 @@
       background-position: 0 50%;
       background-repeat: no-repeat;
       cursor: pointer;
-      padding-left: 2rem;
+      padding-left: u(2rem);
     }
 
     &.sorting {
       @include u-icon-bg($dash, $gray);
-      background-size: 1rem;
+      background-size: u(1rem);
     }
 
     &.sorting_asc {
       @include u-icon-bg($arrow-up-border, $primary);
-      background-size: 1rem;
+      background-size: u(1rem);
     }
 
     &.sorting_desc {
       @include u-icon-bg($arrow-down-border, $primary);
-      background-size: 1rem;
+      background-size: u(1rem);
     }
   }
 
@@ -110,7 +110,7 @@
   td {
     @include transition(padding-left, .2s);
     @include u-truncate();
-    padding: 1rem;
+    padding: u(1rem);
   }
 
   .sorting_disabled {
@@ -118,15 +118,15 @@
   }
 
   .value-bar {
-    margin-top: .5rem;
-    height: .5rem;
+    margin-top: u(.5rem);
+    height: u(.5rem);
   }
 
   @include media($lg) {
     th,
     td {
-      padding-left: 2rem;
-      padding-right: 1rem;
+      padding-left: u(2rem);
+      padding-right: u(1rem);
     }
   }
 
@@ -160,7 +160,7 @@
   }
 
   td:first-child {
-    padding-left: 1rem;
+    padding-left: u(1rem);
     border-left: 1px solid $gray-lightest;
   }
 }
@@ -170,20 +170,20 @@
 // .is-incumbent      - If used, applied to candidate that currently holds the office in election tables
 
 .is-incumbent {
-  margin-left: 1.5rem;
+  margin-left: u(1.5rem);
   position: relative;
 
   &::before {
     background-color: $primary;
-    border-radius: 1rem;
+    border-radius: u(1rem);
     content: '';
     display: block;
-    height: 1rem;
-    left: -1.5rem;
-    margin-top: -.5rem;
+    height: u(1rem);
+    left: u(-1.5rem);
+    margin-top: u(-.5rem);
     position: absolute;
     top: 50%;
-    width: 1rem;
+    width: u(1rem);
   }
 }
 
@@ -210,7 +210,7 @@
 
 // Notes
 .datatable__note {
-  padding: 1rem 0;
+  padding: u(1rem 0);
 
   @include media($med) {
     @include span-columns(9);

--- a/scss/modules/_downloads.scss
+++ b/scss/modules/_downloads.scss
@@ -14,7 +14,7 @@
   font-family: $sans-serif;
   max-height: 50vh;
   overflow: scroll;
-  padding: 1.5rem 0;
+  padding: u(1.5rem 0);
   position: fixed;
   width: 100%;
   z-index: $z-downloads;
@@ -22,28 +22,28 @@
 
 .downloads__title {
   display: block;
-  font-size: 1.6rem;
+  font-size: u(1.6rem);
   font-weight: bold;
-  margin-bottom: 2rem;
+  margin-bottom: u(2rem);
 }
 
 .download {
   @include clearfix();
-  font-size: 1.2rem;
-  margin-bottom: 1rem;
-  padding-left: 3rem;
+  font-size: u(1.2rem);
+  margin-bottom: u(1rem);
+  padding-left: u(3rem);
 
   &.is-pending {
     background-image: url('../img/loading-ellipsis.gif');
-    background-position: 0 .4rem;
+    background-position: u(0 .4rem);
     background-repeat: no-repeat;
-    background-size: 2rem;
+    background-size: u(2rem);
   }
 
   &.is-complete {
     @include u-icon-bg($check, $primary);
-    background-size: 2rem;
-    background-position: 0 .5rem;
+    background-size: u(2rem);
+    background-position: u(0 .5rem);
   }
 }
 
@@ -51,11 +51,11 @@
   @include u-truncate();
   display: block;
   font-weight: bold;
-  padding: .5rem 0;
+  padding: u(.5rem 0);
 }
 
 .download__button {
-  padding: .5rem;
+  padding: u(.5rem);
 }
 
 .download__cancel {
@@ -65,7 +65,7 @@
 
 .download__message {
   letter-spacing: -.3px;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   margin: 0;
 }
 
@@ -85,7 +85,7 @@
 
   .download__button {
     @include span-columns(3);
-    margin: 0 2rem;
+    margin: u(0 2rem);
   }
 }
 
@@ -95,7 +95,7 @@
   }
 
   .download {
-    min-height: 4.2rem;
+    min-height: u(4.2rem);
   }
 
   .download__item {

--- a/scss/modules/_entity-header.scss
+++ b/scss/modules/_entity-header.scss
@@ -3,7 +3,7 @@
 // Styleguide modules.entity-header
 
 .entity__header {
-  padding: 3rem 0;
+  padding: u(3rem 0);
 
   @include media($med) {
     .entity__term {
@@ -16,7 +16,7 @@
   position: relative;
 
   .map {
-    height: 30rem;
+    height: u(30rem);
     width: 100%;
 
     a {
@@ -25,7 +25,7 @@
   }
 
   @include media($med) {
-    height: 30rem;
+    height: u(30rem);
 
     .entity__header--info {
       @include span-columns(6);
@@ -34,7 +34,7 @@
     .map {
       position: absolute;
       width: 50%;
-      height: 34rem;
+      height: u(34rem);
       top: 0;
       bottom: 0;
       right: 0;
@@ -43,11 +43,11 @@
 }
 
 .entity__header__top {
-  padding-bottom: .5rem;
+  padding-bottom: u(.5rem);
 }
 
 .entity__header__bottom {
-  padding: 2rem 0 0 0;
+  padding: u(2rem 0 0 0);
 }
 
 .entity__name {
@@ -67,7 +67,7 @@
   border-top: 2px solid;
   font-family: $sans-serif;
   letter-spacing: -.3px;
-  padding: 1rem 0;
+  padding: u(1rem 0);
   width: 100%;
 
   @include media($med) {
@@ -78,7 +78,7 @@
 .entity__term {
   @include clearfix();
   width: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 
   &:last-child {
     margin-bottom: 0;
@@ -88,7 +88,7 @@
     display: table-cell;
     width: auto;
     margin-bottom: 0;
-    padding-right: 3rem;
+    padding-right: u(3rem);
   }
 }
 
@@ -99,8 +99,8 @@
 }
 
 .entity__term--icon {
-  min-width: 3rem;
-  width: 3rem;
+  min-width: u(3rem);
+  width: u(3rem);
   text-align: center;
 }
 
@@ -128,7 +128,7 @@
 
 .entity__election {
   clear: both;
-  padding-top: 1rem;
+  padding-top: u(1rem);
 
   .entity__term__label {
     width: 100%;
@@ -160,8 +160,8 @@
 @include media($med) {
   .entity__type {
     display: inline-block;
-    margin-right: 1rem;
-    padding-right: 1rem;
+    margin-right: u(1rem);
+    padding-right: u(1rem);
     border-right: 1px solid;
   }
 

--- a/scss/modules/_feedback.scss
+++ b/scss/modules/_feedback.scss
@@ -2,15 +2,15 @@
 
 .feedback {
   background-color: $base;
-  bottom: .5rem;
+  bottom: u(.5rem);
   color: $inverse;
   display: block;
-  left: .5rem;
+  left: u(.5rem);
   overflow-y: scroll;
-  padding: 2rem .5rem;
+  padding: u(2rem .5rem);
   position: fixed;
-  right: .5rem;
-  top: .5rem;
+  right: u(.5rem);
+  top: u(.5rem);
   z-index: $z-feedback;
 
   legend {
@@ -18,12 +18,12 @@
   }
 
   textarea {
-    height: 7rem;
-    margin-bottom: 2rem;
+    height: u(7rem);
+    margin-bottom: u(2rem);
     border-color: $inverse;
 
     &:last-of-type {
-      margin-bottom: 1rem;
+      margin-bottom: u(1rem);
     }
   }
 
@@ -33,14 +33,14 @@
 
   .label {
     &:first-of-type {
-      margin-top: 2rem;
+      margin-top: u(2rem);
     }
   }
 
   .feedback__close {
     position: absolute;
-    right: 1rem;
-    top: 1rem;
+    right: u(1rem);
+    top: u(1rem);
   }
 
   @include media($lg) {
@@ -48,10 +48,10 @@
     height: 95vh;
     left: auto;
     overflow: auto;
-    padding: 3rem 3rem 0 3rem;
-    right: 4rem;
+    padding: u(3rem 3rem 0 3rem);
+    right: u(4rem);
     top: 5vh;
-    width: 52rem;
+    width: u(52rem);
 
     &[aria-hidden='true'] {
       display: block !important;
@@ -62,17 +62,17 @@
 
 .feedback__title {
   @include heading(h2);
-  margin-bottom: .5rem;
+  margin-bottom: u(.5rem);
 }
 
 .feedback__toggle {
   bottom: 0;
   border-radius: 2px 2px 0 0;
   position: fixed;
-  right: 4rem;
+  right: u(4rem);
   z-index: $z-feedback;
 }
 
 .feedback__button {
-  margin-top: 1rem;
+  margin-top: u(1rem);
 }

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -34,7 +34,7 @@
     left: 0;
     height: auto;
     margin-left: 0%;
-    padding: 1rem 0;
+    padding: u(1rem 0);
 
     .filters__hider {
       height: auto;
@@ -43,21 +43,21 @@
   }
 
   .accordion__button {
-    padding-left: 2rem;
-    padding-right: 5rem;
+    padding-left: u(2rem);
+    padding-right: u(5rem);
   }
 
   .accordion__content {
-    padding: 2rem 2rem 1rem 2rem;
+    padding: u(2rem 2rem 1rem 2rem);
   }
 
   .toggles {
-    margin: 1rem 0;
+    margin: u(1rem 0);
   }
 }
 
 .filters--fixed {
-  margin-right: 2rem;
+  margin-right: u(2rem);
 }
 
 .filters__hider {
@@ -69,11 +69,11 @@
   background-color: $primary;
   border: 1px solid $primary-contrast;
   border-radius: 3px;
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   color: $primary-contrast;
-  padding: .5rem;
+  padding: u(.5rem);
   float: left;
-  margin-right: 1rem;
+  margin-right: u(1rem);
 
   &[aria-hidden="false"] {
     display: block;
@@ -88,16 +88,16 @@
 
 .filters__clear {
   @include u-icon-bg($x, $primary-contrast);
-  background-size: 1.4rem;
+  background-size: u(1.4rem);
   background-position: 95% 50%;
-  padding-right: 2.5rem;
+  padding-right: u(2.5rem);
 }
 
 .filter__header {
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 
   @include media($lg) {
-    margin-bottom: 1.5rem;
+    margin-bottom: u(1.5rem);
   }
 }
 
@@ -105,10 +105,10 @@
   border-top: 2px solid $primary;
   display: block;
   font-family: $sans-serif;
-  font-size: 1.8rem;
+  font-size: u(1.8rem);
   font-weight: bold;
-  margin: 3rem 0 1rem 0;
-  padding: 2rem 0 0 0;
+  margin: u(3rem 0 1rem 0);
+  padding: u(2rem 0 0 0);
   text-transform: uppercase;
   width: 100%;
 
@@ -118,11 +118,11 @@
 }
 
 .filters__inner {
-  padding: 1rem 2rem;
+  padding: u(1rem 2rem);
 }
 
 .filters__message-container {
-  padding: 0 2rem 2rem 2rem;
+  padding: u(0 2rem 2rem 2rem);
 
   .message {
     margin: 0;
@@ -131,8 +131,8 @@
 
 .filter {
   border-bottom: 1px solid darken($neutral, 10%);
-  margin-top: 1.5rem;
-  padding-bottom: .5rem;
+  margin-top: u(1.5rem);
+  padding-bottom: u(.5rem);
 
   &:first-child {
     margin-top: 0;
@@ -152,24 +152,24 @@
 
   [type="text"],
   .dropdown__button {
-    margin-bottom: 1rem;
+    margin-bottom: u(1rem);
   }
 }
 
 .filter__instructions {
   display: block;
   font-family: $sans-serif;
-  font-size: 1.2rem;
+  font-size: u(1.2rem);
   line-height: 1;
-  padding: .5rem;
+  padding: u(.5rem);
 }
 
 // Horizontal layout
 
 .filters--horizontal {
   background-color: $neutral;
-  margin-bottom: 2rem;
-  padding: 2rem;
+  margin-bottom: u(2rem);
+  padding: u(2rem);
 }
 
 // BREAKPOINT: MEDIUM
@@ -208,10 +208,10 @@
   .filters {
     @include transition(margin-left .2s);
     float: left;
-    margin-left: -30rem;
-    padding: 2rem 0;
+    margin-left: u(-30rem);
+    padding: u(2rem 0);
     position: relative;
-    width: 30rem;
+    width: u(30rem);
     vertical-align: top;
 
     form {
@@ -250,7 +250,7 @@
       border-top: none;
       border-right: 1px solid $inverse;
       margin-right: 0;
-      padding: 0 1rem;
+      padding: u(0 1rem);
       width: 100%;
 
       &:first-child {

--- a/scss/modules/_footer.scss
+++ b/scss/modules/_footer.scss
@@ -20,17 +20,17 @@
 .footer {
   @include u-bg--primary();
   @include u-font-color($neutral);
-  padding: 5rem 0;
+  padding: u(5rem 0);
 
   .address__title {
-    font-size: 2.2rem;
+    font-size: u(2.2rem);
     font-weight: bold;
   }
 
   .address__subtitle {
-    font-size: 1.8rem;
+    font-size: u(1.8rem);
     font-weight: bold;
-    margin-top: 2rem;
+    margin-top: u(2rem);
   }
 
   @include media($med) {
@@ -56,7 +56,7 @@
 
   p {
     font-family: $sans-serif;
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
     letter-spacing: -.3px;
     color: $secondary-contrast;
   }

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -6,9 +6,9 @@
   @include transition(right, .3s);
   background-color: $base;
   bottom: 0;
-  max-width: 30rem;
+  max-width: u(30rem);
   overflow-y: scroll;
-  padding: 8rem 3rem;
+  padding: u(8rem 3rem);
   position: fixed;
   top: 0;
   width: 75%;
@@ -40,7 +40,7 @@
 }
 
 .glossary__content {
-  padding: 4rem 0;
+  padding: u(4rem 0);
 }
 
 .glossary__definition {
@@ -84,6 +84,6 @@
 }
 
 .term--p {
-  margin-right: .5rem;
+  margin-right: u(.5rem);
   box-shadow: none;
 }

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -52,7 +52,7 @@
   @include u-icon-bg($book, $base);
   background-position: 0% 50%;
   background-size: 1em;
-  padding-left: 2.5rem;
+  padding-left: u(2.5rem);
 }
 
 // Term classes

--- a/scss/modules/_hero.scss
+++ b/scss/modules/_hero.scss
@@ -21,7 +21,7 @@
 // Styleguide modules.hero
 
 .hero {
-  padding: 3rem 0;
+  padding: u(3rem 0);
   text-align: center;
 
   .t-display {
@@ -29,7 +29,7 @@
   }
 
   @include media($med) {
-    padding: 7rem 0;
+    padding: u(7rem 0);
   }
 }
 
@@ -66,26 +66,26 @@
 .hero__down {
   @include u-icon-bg($arrow-down, $secondary-contrast);
   background-position: 50% 100%;
-  padding-bottom: 3rem;
+  padding-bottom: u(3rem);
 }
 
 .hero__content {
-  padding-top: 2rem;
+  padding-top: u(2rem);
 
   @include media($lg) {
     @include span-columns(8);
     @include shift(2);
-    padding-top: 4rem;
+    padding-top: u(4rem);
 
     .combo--search {
       @include span-columns(8 of 8);
     }
 
     .search__radio__button {
-      font-size: 2rem;
-      height: 6rem;
+      font-size: u(2rem);
+      height: u(6rem);
       line-height: 1;
-      padding: 2rem;
+      padding: u(2rem);
     }
   }
 }
@@ -95,7 +95,7 @@
   padding: 0;
 
   .hero__content {
-    padding: 2rem 0;
+    padding: u(2rem 0);
   }
 }
 
@@ -103,7 +103,7 @@
   background-position: right center;
   background-repeat: no-repeat;
   background-size: cover;
-  height: 32rem;
+  height: u(32rem);
   position: relative;
 
   .hero__title {
@@ -111,21 +111,21 @@
   }
 
   .hero__subtitle {
-    padding: 2rem 0;
+    padding: u(2rem 0);
   }
 
   .hero__heading {
-    padding-top: 4rem;
+    padding-top: u(4rem);
   }
 
   .photo-credit {
     background: rgba($gray-lightest, .6);
-    font-size: 1rem;
+    font-size: u(1rem);
     font-family: $sans-serif;
     position: absolute;
     right: 0;
     bottom: 0;
-    padding: .5rem;
+    padding: u(.5rem);
   }
 
   @include media($lg) {
@@ -149,11 +149,11 @@
     background-position: right center;
     background-repeat: no-repeat;
     background-size: cover;
-    height: 20rem;
+    height: u(20rem);
   }
 
   @include media($lg) {
     background-size: cover;
-    height: 28rem;
+    height: u(28rem);
   }
 }

--- a/scss/modules/_nav.scss
+++ b/scss/modules/_nav.scss
@@ -31,10 +31,10 @@
   @include transition(transform, .2s);
   background-color: $primary;
   border-right: 1px solid $primary-contrast;
-  padding: 1rem 2rem;
+  padding: u(1rem 2rem);
   position: absolute;
   left: 0;
-  top: 7rem;
+  top: u(7rem);
   bottom: 0;
   z-index: $z-navigation;
 
@@ -68,9 +68,9 @@
   @include transition(background-color, .1s);
   color: $inverse;
   display: block;
-  font-size: 1.6rem;
-  line-height: 2rem;
-  padding: 1rem;
+  font-size: u(1.6rem);
+  line-height: u(2rem);
+  padding: u(1rem);
   border-bottom: none;
 
   &.is-current {
@@ -86,14 +86,14 @@
 .site-nav__subtitle {
   display: block;
   margin: 0;
-  font-size: 1.4rem;
-  padding: 1rem;
+  font-size: u(1.4rem);
+  padding: u(1rem);
 }
 
 .site-nav__dropdown {
   font-family: $sans-serif;
   display: none;
-  padding-bottom: 2rem;
+  padding-bottom: u(2rem);
 
   &[aria-hidden='false'] {
     display: block;
@@ -104,24 +104,24 @@
   }
 
   .site-nav__link {
-    padding: .5rem 1rem;
-    font-size: 1.4rem;
+    padding: u(.5rem 1rem);
+    font-size: u(1.4rem);
     white-space: nowrap;
   }
 
   .site-nav__sublink {
-    padding-left: 2rem;
+    padding-left: u(2rem);
   }
 }
 
 .site-nav__toggle {
   @include u-icon-bg($arrow-right, $inverse);
   background-position: 0 50%;
-  background-size: 1rem;
+  background-size: u(1rem);
   color: $inverse;
   font-family: $serif;
   text-align: left;
-  padding-left: 2rem;
+  padding-left: u(2rem);
   position: relative;
   width: 100%;
 }
@@ -138,16 +138,16 @@
   border-radius: 0;
   border: none;
   margin: 0;
-  padding: 1.8rem 2rem;
+  padding: u(1.8rem 2rem);
   text-indent: -99999px;
 }
 
 .site-nav__button--left {
   @include u-icon-bg($menu, $primary);
   background-position: 50% 50%;
-  background-size: 2rem;
+  background-size: u(2rem);
   float: left;
-  height: 4rem;
+  height: u(4rem);
 
   &:hover {
     background-color: $inverse;
@@ -163,9 +163,9 @@
 .site-nav__button--right {
   @include u-icon-bg($book, $secondary);
   background-position: 50% 50%;
-  background-size: 2rem;
+  background-size: u(2rem);
   float: right;
-  height: 4rem;
+  height: u(4rem);
 
   &:hover {
     @include u-icon-bg($book, $inverse);
@@ -178,21 +178,21 @@
 
 @include media($med) {
   .site-nav__list {
-    top: 17rem;
+    top: u(17rem);
   }
 
   .site-nav__button {
-    width: 9rem;
+    width: u(9rem);
   }
 
   .site-nav__button--left {
-    background-position: 90% 1rem;
-    font-size: 1.4rem;
+    background-position: u(90% 1rem);
+    font-size: u(1.4rem);
     text-indent: 0;
-    padding: 1rem 4rem 1rem 1rem;
+    padding: u(1rem 4rem 1rem 1rem);
 
     &.active {
-      background-position: 90% 1rem;
+      background-position: u(90% 1rem);
     }
   }
 }
@@ -212,7 +212,7 @@
     overflow: visible;
     display: block;
     float: left;
-    padding: 0 0 0 2rem;
+    padding: u(0 0 0 2rem);
     top: 0;
     position: relative;
     width: 100%;
@@ -257,7 +257,7 @@
   .site-nav__link {
     color: $primary;
     border-bottom: .5rem solid transparent;
-    padding: 1rem 2rem .5rem 2rem;
+    padding: u(1rem 2rem .5rem 2rem);
 
     &:hover,
     &:focus,

--- a/scss/modules/_page-controls.scss
+++ b/scss/modules/_page-controls.scss
@@ -30,8 +30,7 @@
 
 .page-controls {
   @include clearfix();
-  padding: 0 2rem;
-
+  padding: u(0 2rem); 
   .container {
     padding: 0;
   }
@@ -43,7 +42,7 @@
 
 .page-controls__top {
   display: none;
-  padding: 1rem 0;
+  padding: u(1rem 0);
 }
 
 .page-tabs {
@@ -53,7 +52,7 @@
 }
 
 .page-tabs__years {
-  padding: .5rem;
+  padding: u(.5rem);
 }
 
 .page-tabs__list {
@@ -74,12 +73,12 @@
     border-left-width: 1px;
     border-style: solid;
     font-family: $sans-serif;
-    font-size: 1.4rem;
+    font-size: u(1.4rem);
     display: block;
-    letter-spacing: -.05rem;
-    line-height: 2rem;
+    letter-spacing: u(-.05rem);
+    line-height: u(2rem);
     margin-bottom: 0;
-    padding: .5rem;
+    padding: u(.5rem);
     text-decoration: none;
 
     &[aria-selected="true"] {
@@ -138,7 +137,7 @@
 
   .page-tabs__item {
     a {
-      padding: 1rem;
+      padding: u(1rem);
     }
   }
 }
@@ -155,7 +154,7 @@
   }
 
   .page-tabs__years {
-    padding: 1rem 2rem 1rem 0;
+    padding: u(1rem 2rem 1rem 0);
 
     h2 {
       margin: 0;
@@ -164,7 +163,7 @@
 
   .page-tabs__item {
     a {
-      padding: 1rem 2rem;
+      padding: u(1rem 2rem);
     }
   }
 }

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -8,12 +8,12 @@
   @include clearfix();
   border-top: 2px solid $primary;
   border-bottom: 2px solid $primary;
-  padding: 1rem 1rem;
+  padding: u(1rem 1rem);
 }
 
 .results-info__left {
   @include clearfix();
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .results-info__right {
@@ -26,7 +26,7 @@
 }
 
 .results-info__download {
-  margin-top: 1rem;
+  margin-top: u(1rem);
 }
 
 .results-info__details {
@@ -44,12 +44,12 @@
 
     .dataTables_paginate {
       float: right;
-      padding: .5rem 0;
+      padding: u(.5rem 0);
     }
 
     .dataTables_length {
       float: left;
-      line-height: 2rem;
+      line-height: u(2rem);
 
       select {
         display: inline;
@@ -92,11 +92,11 @@
     }
 
     .dataTables_length {
-      padding: 0 1rem 0 0;
+      padding: u(0 1rem 0 0);
     }
 
     .dataTables_paginate {
-      padding: .5rem 0;
+      padding: u(.5rem 0);
     }
   }
 }
@@ -104,6 +104,6 @@
 // BREAKPOINT: LARGE
 @include media($lg) {
   .results-info {
-    padding: 1rem 0;
+    padding: u(1rem 0);
   }
 }

--- a/scss/modules/_search-controls.scss
+++ b/scss/modules/_search-controls.scss
@@ -7,7 +7,7 @@
 .search-controls__row {
   @include clearfix();
   border-bottom: 1px solid $gray;
-  padding: 1rem 0;
+  padding: u(1rem 0);
 
   &:first-of-type {
     padding-top: 0;
@@ -23,7 +23,7 @@
 // Component with two halves, separated by an "or"
 
 .search-controls__or {
-  margin: 1rem 0;
+  margin: u(1rem 0);
   position: relative;
   text-align: center;
   width: 100%;
@@ -36,7 +36,7 @@
     position: absolute;
     height: 1px;
     width: 45%;
-    top: 1rem;
+    top: u(1rem);
   }
 
   &::before {
@@ -63,7 +63,7 @@
 
 .search-controls__state {
   @include span-columns(6);
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 
   select {
     width: 100%;
@@ -85,7 +85,7 @@
 
 @include media($med) {
   .search-controls__row {
-    padding: 2rem 0;
+    padding: u(2rem 0);
   }
 
   .search-controls__either {
@@ -102,23 +102,23 @@
 
   .search-controls__or--vertical {
     @include span-columns(1);
-    margin: 5.5rem 0;
+    margin: u(5.5rem 0);
     text-align: center;
 
     &::before,
     &::after {
-      height: 6.5rem;
+      height: u(6.5rem);
       left: 50%;
       width: 1px;
     }
 
     &::before {
-      top: -6.5rem;
+      top: u(-6.5rem);
     }
 
     &::after {
       top: auto;
-      bottom: -6.5rem;
+      bottom: u(-6.5rem);
     }
   }
 }

--- a/scss/modules/_section-headings.scss
+++ b/scss/modules/_section-headings.scss
@@ -17,31 +17,31 @@
 .section__heading {
   @include clearfix();
   border-bottom: 2px solid;
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .heading__title {
   border-bottom: 0;
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .heading__subtitle {
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .heading__action {
-  margin-bottom: 1rem;
+  margin-bottom: u(1rem);
 }
 
 .heading__action__top {
-  margin-top: -1rem;
-  margin-bottom: 1rem;
+  margin-top: u(-1rem);
+  margin-bottom: u(1rem);
   text-align: right;
 }
 
 .heading__action__left {
   float: left;
-  margin-right: 1rem;
+  margin-right: u(1rem);
 }
 
 .heading__action__right {
@@ -51,7 +51,7 @@
 
 .heading__link-name {
   display: block;
-  font-size: 1.2rem;
+  font-size: u(1.2rem);
 }
 
 .heading__message {

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -8,7 +8,7 @@
   background-color: $navy;
   color: $inverse;
   font-family: $sans-serif;
-  padding: 1rem 0;
+  padding: u(1rem 0);
   width: 100%;
 
   a {
@@ -24,10 +24,10 @@
   border: 2px solid $primary-contrast;
   color: $inverse;
   font-family: $sans-serif;
-  left: 2rem;
-  padding: 1rem 2rem;
+  left: u(2rem);
+  padding: u(1rem 2rem);
   position: absolute;
-  top: -10rem;
+  top: u(-10rem);
   z-index: $z4;
 
   &:focus {
@@ -54,9 +54,9 @@
   border-bottom: 1px solid $neutral;
   color: $gray-dark;
   font-family: $sans-serif;
-  font-size: 1.2rem;
+  font-size: u(1.2rem);
   line-height: 1;
-  padding: 5px 2rem;
+  padding: u(5px 2rem);
   text-align: center;
 }
 
@@ -149,7 +149,7 @@
   font-family: $sans-serif;
   display: none;
   float: right;
-  padding: 1.6rem 0;
+  padding: u(1.6rem 0);
 
   @include media($lg) {
     display: block;
@@ -158,10 +158,10 @@
 
 li.utility-nav__item {
   margin-right: 0;
-  padding: 0 1.5rem;
+  padding: u(0 1.5rem);
   border-left: 1px solid $gray;
-  line-height: 1.6rem;
-  font-size: 1.4rem;
+  line-height: u(1.6rem);
+  font-size: u(1.4rem);
 
   &:first-child {
     border-left: none;
@@ -188,10 +188,10 @@ li.utility-nav__item {
     @include u-background-image('wordmark', 0% 50%);
     background-size: contain;
     display: block;
-    height: 3rem;
-    margin: .5rem 1rem;
+    height: u(3rem);
+    margin: u(.5rem 1rem);
     width: calc(100% - 15rem);
-    max-width: 40rem;
+    max-width: u(40rem);
 
     @include media($med) {
       display: none;

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -81,7 +81,7 @@
 
   .disclaimer__left {
     display: block;
-    padding-left: 1rem;
+    padding-left: u(1rem);
   }
 
   .disclaimer__right {
@@ -113,7 +113,7 @@
     @include u-background-image('seal--cropped', 0% 100%);
     border-bottom: 2px solid $neutral;
     display: block;
-    background-size: 11rem;
+    background-size: u(11rem);
   }
 }
 
@@ -135,8 +135,8 @@
     @include u-background-image('wordmark', 0% 50%);
     background-size: contain;
     display: block;
-    margin: 1rem 0 .7rem 12rem;
-    height: 3.4rem;
+    margin: u(1rem 0 .7rem 12rem);
+    height: u(3.4rem);
     width: 100%;
   }
 

--- a/scss/modules/_totals-tables.scss
+++ b/scss/modules/_totals-tables.scss
@@ -8,7 +8,7 @@
 
 .totals-table {
   font-family: $sans-serif;
-  font-size: 1.6rem;
+  font-size: u(1.6rem);
   letter-spacing: -.3px;
 }
 
@@ -19,10 +19,10 @@
 
 .totals-table__cell {
   width: 100%;
-  padding: 1rem 0;
+  padding: u(1rem 0);
 
   &:first-child {
-    padding: 1rem 0 0 0;
+    padding: u(1rem 0 0 0);
     font-weight: bold;
   }
 }
@@ -34,24 +34,24 @@
 
 .totals-table__header-label {
   display: inline-block;
-  padding-top: 1rem;
+  padding-top: u(1rem);
 }
 
 .totals-table__header-data {
-  font-size: 2rem;
+  font-size: u(2rem);
   font-weight: bold;
 }
 
 .totals-table__row--nested {
-  font-size: 1.4rem;
+  font-size: u(1.4rem);
   background-color: rgba($gray-lightest, .3);
   border-color: $gray-lightest;
-  padding: .5rem 2rem;
+  padding: u(.5rem 2rem);
 
   .totals-table__cell,
   .totals-table__cell:first-child {
     width: 100%;
-    padding-top: .5rem;
+    padding-top: u(.5rem);
   }
 
   .totals-table__cell:first-child {

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -6,6 +6,7 @@
 // Variables and mixins
 @import 'variables';
 @import 'icon-variables';
+@import 'functions';
 @import 'grid';
 @import 'mixins/utilities';
 @import 'mixins/type-mixins';


### PR DESCRIPTION
## Summary

In order to use FEC's styleguide with other frameworks, like eRegs, it needs to be configurable to size components properly. All of FEC's components are based on `rem`s so the components are sized based on the browser's default font size. This works well, except when combined with eRegs, where the browser's effective `rem` size is larger. This ends up with FEC components looking gigantic.

This change introduces a `u()` function used to scale `rem`-based sizes at build time. Two variables `$base-size-px` and `$px-only` affect how the sizes are calculated. For FEC based projects, this means nothing, except that instead of writing `2rem`, you would write `u(2rem)`. For eRegs, by setting these two variables, the FEC components are scaled down and play nice with eRegs.

Note, I also moved the documentation for Utility Mixins to the bottom of the styleguide table of contents. These are advanced sections, not required for understanding the FEC design system, so they seem more appropriately described at the end.

The conversion of the units was done with this (GNU) sed script:
```
# sed -r -i -f wrap-rem-units.sed

# A comment, but jump to `a` to process it
\:rem.*//: b a

# A comment, skip the line.
\://: { p ; d }

: a 

# Wrap the line with the function. i.e. u(1rem 0 10px 0); Matches include:
# font-size: 1rem;
# padding-right: -1rem;
# margin-right: -.1rem;
# margin-right: -12.1rem;
# margin: 1rem 0 0 0;
# margin: 1rem 0 10px 0;
/rem/ s/:\s*((-?([0-9]+)?(\.?[0-9]+)(\w+)?\s*)+)\s*;/: u(\1);/
```

## Screenshots

Creates a new section documenting the new functions.
![screenshot from 2016-05-25 15-40-45](https://cloud.githubusercontent.com/assets/509703/15558455/220d47c2-228f-11e6-95af-e575b44db6ce.png)

cc @noahmanger @msecret @anthonygarvan @annalee 
