### PR TITLE
Reports and filings inconsistency

### DIFF
--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -66,12 +66,12 @@
       </div>
       <div class="mega__column">
         <div class="mega-heading--sub">
-          <h4 class="mega-heading__title icon-heading--filings">Reports and filings</h4>
+          <h4 class="mega-heading__title icon-heading--filings">Filings</h4>
         </div>
         <ul>
           <li class="mega__item"><a href="{{webAppUrl}}/filings">All filings</a></li>
-          <li class="mega__item is-disabled">Authorized committee reports</li>
-          <li class="mega__item is-disabled">Unauthorized committee reports</li>
+          <li class="mega__item is-disabled">Authorized committee filings</li>
+          <li class="mega__item is-disabled">Unauthorized committee filings</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Language consistency update

Related to https://github.com/18F/fec-cms/issues/311, we're starting to think deeply about our word choice on the website. The term `Filings` is a blanket term that encompasses:
- `Statements` (as in Statements of Candidacy), 
- `Reports` (as in Quarterly Reports), and 
- `Notices` (as in 24-Hour Notices). 

For clarity, when we are talking about a broad swath of filings, I want to use the term `Filing`. We can use the other terms in more specific instances. 

This term feels more technical than `report`, but I feel especially okay with it, since it lives in the advanced data section that we created specifically for our power users, who should appreciate precisely this kind of precision and consistency.

Content only. Anyone can review.

