### PR TITLE
Setting color on dropdown values

### DIFF
--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -53,10 +53,6 @@
   }
 }
 
-.dropdown__value {
-  margin: 0;
-}
-
 .dropdown__panel {
   position: absolute;
   min-width: 100%;
@@ -74,6 +70,7 @@
   label.dropdown__value {
     background-color: transparent;
     border-bottom: 1px solid $gray-dark;
+    color: $base;
     display: block;
     margin: 0;
     padding: .5rem 1rem;


### PR DESCRIPTION
## Summary

Sets the color of `dropdown__value` items, so that when they're in a container that sets font color to something else, they always stay `$base`. 

Resolves https://github.com/18F/fec-style/issues/375

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/15693986/e0ad337c-274e-11e6-9704-d7a2ea8892ad.png)


