### PR TITLE
Scale border size based on rem size

### DIFF
--- a/scss/modules/_nav.scss
+++ b/scss/modules/_nav.scss
@@ -256,7 +256,7 @@
 
   .site-nav__link {
     color: $primary;
-    border-bottom: .5rem solid transparent;
+    border-bottom: u(.5rem) solid transparent;
     padding: u(1rem 2rem .5rem 2rem);
 
     &:hover,


### PR DESCRIPTION
## Summary

Missed the `border-size` rem reference in the introducing the `u()` function.
