### PR TITLE
Making h1 border thicker to support hierarchy

### DIFF
--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -18,7 +18,7 @@
   }
 
   @if $level == h1 {
-    border-bottom: 1px solid $base;
+    border-bottom: 2px solid $base;
     font-family: $serif;
     font-size: u(2.4rem);
     font-weight: bold;


### PR DESCRIPTION
## Summary

Makes border on `h1` styles 2px by default. Previously, it was 1px, which was the same as borders on h2 styles.

## Screenshots

<img width="815" alt="screen shot 2016-06-01 at 6 57 06 pm" src="https://cloud.githubusercontent.com/assets/11636908/15728511/d62b1270-282a-11e6-8368-ac4b083cf2f7.png">
<img width="1024" alt="screen shot 2016-06-01 at 6 57 18 pm" src="https://cloud.githubusercontent.com/assets/11636908/15728512/d62bc9d6-282a-11e6-8bea-5e1a84812757.png">



_cc @noahmanger _

