### PR TITLE
Removes "committees"

### DIFF
--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -6,7 +6,7 @@
           <h3 class="mega-heading__title icon-heading--profiles"><a href="{{webAppUrl}}">Profiles</a></h3>
         </div>
         <form action="{{webAppUrl}}" method="GET" autocomplete="off">
-          <label class="t-sans mega__item" for="menu-search">Search for candidates and committees</label>
+          <label class="t-sans mega__item" for="menu-search">Search for candidates.</label>
           <div class="combo--search--mini">
             <input id="menu-search" name="search" class="combo__input js-menu-search" type="text"
             placeholder="Search for candidates"


### PR DESCRIPTION
My understanding is that we want to remove the committees option from the nav until we can actually search committees. Otherwise the functionality is confusing. Let me know if I'm wrong, though!

Content only.

_cc @noahmanger_

