### PR TITLE
Breakpoint checks should account for scrollbar

### DIFF
--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -36,7 +36,7 @@ function FilterPanel(options) {
 }
 
 FilterPanel.prototype.setInitialDisplay = function() {
-  if ($(document).width() > helpers.BREAKPOINTS.LARGE) {
+  if (window.innerWidth >= helpers.BREAKPOINTS.LARGE) {
     this.show();
   } else if (!this.isOpen) {
     this.hide();
@@ -44,7 +44,7 @@ FilterPanel.prototype.setInitialDisplay = function() {
 };
 
 FilterPanel.prototype.setHeight = function() {
-  if ($(document).width() > helpers.BREAKPOINTS.LARGE &&
+  if (window.innerWidth >= helpers.BREAKPOINTS.LARGE &&
       this.$dataContainer.height() > this.$body.height()) {
     this.$body.css('min-height', this.$dataContainer.height());
   }

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -36,7 +36,7 @@ function FilterPanel(options) {
 }
 
 FilterPanel.prototype.setInitialDisplay = function() {
-  if (window.innerWidth >= helpers.BREAKPOINTS.LARGE) {
+  if (helpers.getWindowWidth() >= helpers.BREAKPOINTS.LARGE) {
     this.show();
   } else if (!this.isOpen) {
     this.hide();
@@ -44,7 +44,7 @@ FilterPanel.prototype.setInitialDisplay = function() {
 };
 
 FilterPanel.prototype.setHeight = function() {
-  if (window.innerWidth >= helpers.BREAKPOINTS.LARGE &&
+  if (helpers.getWindowWidth() >= helpers.BREAKPOINTS.LARGE &&
       this.$dataContainer.height() > this.$body.height()) {
     this.$body.css('min-height', this.$dataContainer.height());
   }

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -19,6 +19,12 @@ var formatMap = {
   fullDayOfWeek: 'dddd'
 };
 
+function getWindowWidth() {
+  // window.innerWidth accounts for scrollbars and should match the width used
+  // for media queries.
+  return window.innerWidth;
+}
+
 function datetime(value, options) {
   var hash = options.hash || {};
   var format = formatMap[hash.format || 'default'];
@@ -40,5 +46,6 @@ Handlebars.registerHelper({
 module.exports = {
   datetime: datetime,
   BREAKPOINTS: BREAKPOINTS,
+  getWindowWidth: getWindowWidth,
   helpers: Handlebars.helpers
 };

--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -52,7 +52,7 @@ function SiteNav(selector, opts) {
 }
 
 SiteNav.prototype.initMenu = function() {
-  if (window.innerWidth >= helpers.BREAKPOINTS.LARGE) {
+  if (helpers.getWindowWidth() >= helpers.BREAKPOINTS.LARGE) {
     this.initMegaMenu();
   } else {
     this.initMobileMenu();
@@ -89,7 +89,7 @@ SiteNav.prototype.initMobileMenu = function() {
 };
 
 SiteNav.prototype.switchMenu = function() {
-  if (window.innerWidth < helpers.BREAKPOINTS.LARGE ) {
+  if (helpers.getWindowWidth() < helpers.BREAKPOINTS.LARGE ) {
     this.$body.find('.mega').remove();
     this.initMobileMenu();
   } else if (this.isMobile) {
@@ -101,7 +101,7 @@ SiteNav.prototype.switchMenu = function() {
 
 SiteNav.prototype.assignAria = function() {
   this.$menu.attr('aria-label', 'Site-wide navigation');
-  if (window.innerWidth < helpers.BREAKPOINTS.LARGE) {
+  if (helpers.getWindowWidth() < helpers.BREAKPOINTS.LARGE) {
     this.$toggle.attr('aria-haspopup', true);
     this.$menu.attr('aria-hidden', true);
   }

--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -52,7 +52,7 @@ function SiteNav(selector, opts) {
 }
 
 SiteNav.prototype.initMenu = function() {
-  if ( $('body').width() > helpers.BREAKPOINTS.LARGE) {
+  if (window.innerWidth >= helpers.BREAKPOINTS.LARGE) {
     this.initMegaMenu();
   } else {
     this.initMobileMenu();
@@ -82,12 +82,14 @@ SiteNav.prototype.initMegaMenu = function() {
 };
 
 SiteNav.prototype.initMobileMenu = function() {
-  this.$menu.append(TEMPLATES.mobile(this.opts));
-  this.isMobile = true;
+  if (!this.isMobile) {
+    this.$menu.append(TEMPLATES.mobile(this.opts));
+    this.isMobile = true;
+  }
 };
 
 SiteNav.prototype.switchMenu = function() {
-  if ( $('body').width() < helpers.BREAKPOINTS.LARGE ) {
+  if (window.innerWidth < helpers.BREAKPOINTS.LARGE ) {
     this.$body.find('.mega').remove();
     this.initMobileMenu();
   } else if (this.isMobile) {
@@ -99,7 +101,7 @@ SiteNav.prototype.switchMenu = function() {
 
 SiteNav.prototype.assignAria = function() {
   this.$menu.attr('aria-label', 'Site-wide navigation');
-  if ( $('body').width() < helpers.BREAKPOINTS.LARGE) {
+  if (window.innerWidth < helpers.BREAKPOINTS.LARGE) {
     this.$toggle.attr('aria-haspopup', true);
     this.$menu.attr('aria-hidden', true);
   }

--- a/tests/filter-panel.js
+++ b/tests/filter-panel.js
@@ -10,6 +10,7 @@ var $ = require('jquery');
 
 var FilterPanel = require('../js/filter-panel').FilterPanel;
 var FilterSet = require('../js/filter-set').FilterSet;
+var helpers = require('../js/helpers');
 
 function expectOpen(panel) {
   expect(panel.isOpen).to.be.true;
@@ -55,10 +56,23 @@ describe('filter panel', function() {
     expectClosed(this.panel);
   });
 
-  it('should start off open on wide windows', function() {
-    $('body').width(861);
-    var panel = new FilterPanel();
-    expectOpen(panel);
+  describe('for wide windows', function() {
+    beforeEach(function() {
+      this.originalWidth = $('body').width();
+      var width = 861;
+      sinon.stub(helpers, 'getWindowWidth').returns(width);
+      $('body').width(width);
+    });
+
+    afterEach(function() {
+      $('body').width(this.originalWidth);
+      helpers.getWindowWidth.restore();
+    });
+
+    it('should start off open on wide windows', function() {
+      var panel = new FilterPanel();
+      expectOpen(panel);
+    });
   });
 
   describe('interaction with filterset', function() {

--- a/tests/site-nav.js
+++ b/tests/site-nav.js
@@ -55,6 +55,21 @@ describe('SiteNav', function() {
   });
 
   describe('Desktop configuration', function() {
+    beforeEach(function() {
+      this.originalWidth = $('body').width();
+      var width = 1000;
+      $('body').width(width);
+      sinon.stub(helpers, 'getWindowWidth').returns(width);
+
+      this.$fixture.empty().append(dom);
+      this.siteNav = new SiteNav('.js-site-nav');
+    });
+
+    afterEach(function() {
+      $('body').width(this.originalWidth);
+      helpers.getWindowWidth.restore();
+    });
+
     describe('assignAria()', function() {
       it('should assign aria attributes to the list', function() {
         expect(this.siteNav.$menu.attr('aria-label')).to.equal('Site-wide navigation');

--- a/tests/site-nav.js
+++ b/tests/site-nav.js
@@ -4,10 +4,12 @@
 
 var chai = require('chai');
 var expect = chai.expect;
+var sinon = require('sinon');
 
 var $ = require('jquery');
 
 var SiteNav = require('../js/site-nav').SiteNav;
+var helpers = require('../js/helpers');
 
 var dom = '<nav class="site-nav js-site-nav">' +
   '<div id="site-menu" class="site-nav__container">' +
@@ -68,13 +70,16 @@ describe('SiteNav', function() {
 
   describe('Mobile configuration', function() {
     beforeEach(function() {
-      $('body').width(400);
+      var width = 400;
+      sinon.stub(helpers, 'getWindowWidth').returns(width);
+      $('body').width(width);
       this.$fixture.empty().append(dom);
       this.siteNav = new SiteNav('.js-site-nav');
     });
 
     afterEach(function() {
       $('body').width(1000);
+      helpers.getWindowWidth.restore();
     });
 
     describe('initMobileMenu()', function() {
@@ -130,8 +135,16 @@ describe('SiteNav', function() {
   describe('switchMenu()', function() {
     describe('when switching to a small screen', function() {
       before(function() {
-        $('body').width(400);
+        this.originalWidth = $('body').width();
+        var width = 400;
+        sinon.stub(helpers, 'getWindowWidth').returns(width);
+        $('body').width(width);
         this.siteNav.switchMenu();
+      });
+
+      after(function() {
+        $('body').width(this.originalWidth);
+        helpers.getWindowWidth.restore();
       });
 
       it('should remove the mega menu', function() {
@@ -145,8 +158,16 @@ describe('SiteNav', function() {
 
     describe('when switching to a large screen', function() {
       before(function() {
-        $('body').width(1000);
+        this.originalWidth = $('body').width();
+        var width = 1000;
+        sinon.stub(helpers, 'getWindowWidth').returns(width);
+        $('body').width(width);
         this.siteNav.switchMenu();
+      });
+
+      after(function() {
+        $('body').width(this.originalWidth);
+        helpers.getWindowWidth.restore();
       });
 
       it('should remove the mobile menu if the screen gets big', function() {


### PR DESCRIPTION
Fixes #385 

Shows up as a revert because I accidentally committed the fix directly to master, then reverted it. This reverts the revert, re-instituting the fix. This actually fixes three things:

- Use `window.innerWidth` to include the scrollbar widths, which will be the same value used for media queries.
- Avoid appending multiple `.js-mobile-nav` elements on every `resize` event.
- Off-by-one breakpoint calculations. 860px should be considered large, because we're using `min-width` in our media queries.
