### PR TITLE
20160608 fixes

### DIFF
--- a/js/sticky-bar.js
+++ b/js/sticky-bar.js
@@ -6,7 +6,7 @@ function StickyBar(selector) {
   this.$body = $('body');
   this.$bar = $(selector);
   this.offset = this.$bar.offset().top;
-  this.triggerOffset = this.$bar.data('trigger-offset'); // Delay before it sticks
+  this.triggerOffset = this.$bar.data('trigger-offset') || 0; // Delay before it sticks
 
   this.defaultBodyPadding = this.$body.css('padding-top');
   $(window).on('scroll', this.toggle.bind(this));

--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -42,7 +42,7 @@
       </div>
     </div>
     <div class="mega-heading">
-      <h3 class="mega-heading__title icon-heading--table">Advanced data</h3>
+      <h3 class="mega-heading__title icon-heading--table"><a href="{{webAppUrl}}/advanced">Advanced data</a></h3>
     </div>
     <div class="mega__group">
       <div class="mega__column">
@@ -70,9 +70,10 @@
         </div>
         <ul>
           <li class="mega__item"><a href="{{webAppUrl}}/filings">All filings</a></li>
-          <li class="mega__item is-disabled">Authorized committee filings</li>
-          <li class="mega__item is-disabled">Unauthorized committee filings</li>
+          <li class="mega__item is-disabled">Authorized committee reports</li>
+          <li class="mega__item is-disabled">Unauthorized committee reports</li>
         </ul>
+        <a class="button button--standard button--table" href="{{webAppUrl}}/advanced">Full advanced data list</a>
       </div>
     </div>
     <div class="row">

--- a/scss/components/_mega-menu.scss
+++ b/scss/components/_mega-menu.scss
@@ -1,12 +1,16 @@
 // Mega menu
 
 .mega {
-  a {
+  a:not(.button) {
     border-bottom: none;
 
     &:hover {
       border-bottom: 1px dotted $inverse;
     }
+  }
+
+  ul {
+    margin-left: 0;
   }
 }
 
@@ -35,7 +39,7 @@
       }
     }
 
-    a {
+    a:not(.button) {
       border-color: $inverse;
     }
   }
@@ -49,6 +53,10 @@
     font-size: u(1.4rem);
     color: $inverse;
     padding: u(1rem 4rem 2rem 4rem);
+
+    .button--standard {
+      color: $base;
+    }
   }
 
   .mega-heading {

--- a/scss/components/_mega-menu.scss
+++ b/scss/components/_mega-menu.scss
@@ -1,7 +1,7 @@
 // Mega menu
 
 .mega {
-  a:not(.button) {
+  a {
     border-bottom: none;
 
     &:hover {
@@ -39,7 +39,7 @@
       }
     }
 
-    a:not(.button) {
+    a {
       border-color: $inverse;
     }
   }
@@ -56,6 +56,7 @@
 
     .button--standard {
       color: $base;
+      border: 1px solid $gray;
     }
   }
 


### PR DESCRIPTION
## Summary
- Adding link and button to the advanced data page
- Sets a default `triggerOffset` to 0 if the data attribute isn't set on the sticky bar element

Resolves https://github.com/18F/openFEC-web-app/issues/1255
Resolves https://github.com/18F/openFEC-web-app/issues/1228

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/15840351/2780bd9c-2bfe-11e6-8cee-ea967f3df631.png)

cc @adborden 