### PR TITLE
Mega menu sizing

### DIFF
--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -42,7 +42,7 @@
       </div>
     </div>
     <div class="mega-heading">
-      <h3 class="mega-heading__title icon-heading--table"><a href="{{webAppUrl}}/advanced">Advanced data</a></h3>
+      <h3 class="mega-heading__title icon-heading--table"><a href="{{webAppUrl}}/advanced">Advanced data - all</a></h3>
     </div>
     <div class="mega__group">
       <div class="mega__column">
@@ -73,7 +73,6 @@
           <li class="mega__item is-disabled">Authorized committee reports</li>
           <li class="mega__item is-disabled">Unauthorized committee reports</li>
         </ul>
-        <a class="button button--standard button--table" href="{{webAppUrl}}/advanced">Full advanced data list</a>
       </div>
     </div>
     <div class="row">

--- a/scss/components/_mega-menu.scss
+++ b/scss/components/_mega-menu.scss
@@ -96,8 +96,8 @@
   }
 
   .mega__item {
-    line-height: 1.2;
-    margin-bottom: u(1.2rem);
+    line-height: 1;
+    margin-bottom: u(1rem);
   }
 
   .mega__item__sub {


### PR DESCRIPTION
## Summary

- Reduces the height of the mega menu so that it avoids hitting the bottom window frame as much as possible
- Resolves https://github.com/18F/fec-style/issues/389


## Screenshots

<img width="1278" alt="screen shot 2016-06-14 at 12 10 43 pm" src="https://cloud.githubusercontent.com/assets/11636908/16050932/92cffcf6-322b-11e6-8f8d-08e1dad97d51.png">


### Review
@noahmanger 

### Tasks to completion

- [x] Agree on approach for integrating link to Adv data page from https://github.com/18F/fec-style/issues/389
