### PR TITLE
Fixing filter panel test

### DIFF
--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -51,7 +51,7 @@ FilterPanel.prototype.setHeight = function() {
 };
 
 FilterPanel.prototype.show = function() {
-  this.$body.addClass('is-open');
+  this.$body.addClass('is-open').attr('aria-hidden', false);
   this.$toggle.attr('aria-hidden', true);
   accessibility.restoreTabindex(this.$form);
   $('body').addClass('is-showing-filters');
@@ -60,7 +60,7 @@ FilterPanel.prototype.show = function() {
 };
 
 FilterPanel.prototype.hide = function() {
-  this.$body.removeClass('is-open');
+  this.$body.removeClass('is-open').attr('aria-hidden', true);
   this.$toggle.attr('aria-hidden', false);
   this.$focus.focus();
   accessibility.removeTabindex(this.$form);

--- a/tests/filter-panel.js
+++ b/tests/filter-panel.js
@@ -58,14 +58,13 @@ describe('filter panel', function() {
 
   describe('for wide windows', function() {
     beforeEach(function() {
-      this.originalWidth = $('body').width();
       var width = 861;
       sinon.stub(helpers, 'getWindowWidth').returns(width);
       $('body').width(width);
     });
 
     afterEach(function() {
-      $('body').width(this.originalWidth);
+      $('body').width(960);
       helpers.getWindowWidth.restore();
     });
 


### PR DESCRIPTION
## Summary
- Fixes failing tests caused by `this.originalWidth` returning a value of `384` instead of a desktop-sized width. (Not sure why it was doing this).
- While investigating this, I realized we weren't setting `aria-hidden` correctly on the filter panel, so I fixed that as well.

cc @adborden