### PR TITLE
fixing rem calc bug

### DIFF
--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -22,6 +22,8 @@
 //
 // Styleguide components.search-bar
 
+$search-button-width: u(5.6rem);
+
 .search__select {
   border-radius: 4px 0 0 4px;
   margin-right: -2px;
@@ -42,7 +44,6 @@
   .combo__input {
     border-radius: 4px 0 0 4px;
     float: left;
-    $search-button-width: u(5.6rem);
     width: calc(100% - #{$search-button-width});
 
     .combo__input {
@@ -77,7 +78,7 @@
     }
 
     .combo__button {
-      width: u(5.6rem);
+      width: #{$search-button-width};
     }
 
     .tt-menu {

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -42,7 +42,8 @@
   .combo__input {
     border-radius: 4px 0 0 4px;
     float: left;
-    width: calc(100% - 5.6rem);
+    $search-button-width: u(5.6rem);
+    width: calc(100% - #{$search-button-width});
 
     .combo__input {
       width: 100%;

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -78,7 +78,7 @@ $search-button-width: u(5.6rem);
     }
 
     .combo__button {
-      width: #{$search-button-width};
+      width: $search-button-width;
     }
 
     .tt-menu {


### PR DESCRIPTION
I am fixing this in one place (where it was causing me an issue) but it may be a widespread problem. Anyplace the a `calc(X - Yrem)` is used in order to offset by an element of width `u(Yrem)`, the offset will be broken when you adapt the mode (eg,. fec-eregs sets $px-only to `true`, which surfaced this bug).