### PR TITLE
Adjusting accordion and totals-table styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test-single": "karma start --single-run --browsers PhantomJS"
   },
   "dependencies": {
-    "aria-accordion": "0.1.0",
+    "aria-accordion": "0.1.1",
     "glossary-panel": "0.1.2",
     "eventemitter2": "0.4.14",
     "jquery": "2.1.4",

--- a/scss/components/_accordions.scss
+++ b/scss/components/_accordions.scss
@@ -28,19 +28,23 @@
 }
 
 .accordion__content {
+  @include clearfix();
   border-bottom: 1px solid $base;
   padding: u(1rem);
+}
+
+.accordion__button--spacious {
+  padding: u(2rem 4rem 2rem 2rem);
 }
 
 .accordion--neutral {
   .accordion__button {
     background-color: $gray-lightest;
-    border-color: $gray;
-    border-top: 1px solid $gray;
+    border-top: 1px solid $primary;
 
     &[aria-expanded='true'] {
       background-color: $gray-light;
-      border-top: 1px solid $base;
+      border-bottom: 1px solid $gray;
     }
   }
 

--- a/scss/components/_type-styles.scss
+++ b/scss/components/_type-styles.scss
@@ -93,6 +93,7 @@
 // .t-serif         - Force serif
 // .t-italic        - Italicize
 // .t-bold          - Embolden!
+// .t-normal        - Normal weight
 // .t-highlight     - Highlight
 // .t-upper         - Transform to uppercase
 // .t-data-header   - Small header above a big data number
@@ -142,6 +143,10 @@
 
 .t-bold {
   font-weight: bold;
+}
+
+.t-normal {
+  font-weight: normal;
 }
 
 .t-hightlight {

--- a/scss/modules/_totals-tables.scss
+++ b/scss/modules/_totals-tables.scss
@@ -14,17 +14,30 @@
 
 .totals-table__row {
   @include clearfix();
-  border-bottom: 1px solid $primary;
+
+  .row {
+    display: table;
+    width: 100%;
+  }
 }
 
 .totals-table__cell {
-  width: 100%;
+  display: table-cell;
   padding: u(1rem 0);
 
   &:first-child {
-    padding: u(1rem 0 0 0);
     font-weight: bold;
   }
+
+  &:nth-child(2) {
+    text-align: right;
+  }
+}
+
+.totals-table__cell--bar {
+  width: 100%;
+  padding: 0;
+  background-color: $gray-lightest;
 }
 
 .totals-table__label {
@@ -33,8 +46,9 @@
 }
 
 .totals-table__header-label {
-  display: inline-block;
-  padding-top: u(1rem);
+  display: block;
+  font-weight: bold;
+  padding-bottom: u(1rem);
 }
 
 .totals-table__header-data {
@@ -44,37 +58,23 @@
 
 .totals-table__row--nested {
   font-size: u(1.4rem);
-  background-color: rgba($gray-lightest, .3);
-  border-color: $gray-lightest;
   padding: u(.5rem 2rem);
-
-  .totals-table__cell,
-  .totals-table__cell:first-child {
-    width: 100%;
-    padding-top: u(.5rem);
-  }
-
-  .totals-table__cell:first-child {
-    font-weight: normal;
-  }
 }
 
 @include media($med) {
   .totals-table__row,
   .totals-table__row--nested {
-    .totals-table__cell {
-      float: left;
-      width: 20%;
+    .totals-table__cell,
+    .totals-table__cell:first-child {
       padding: .5em 0;
-
-      &:first-child {
-        width: 40%;
-        padding: .5em 0;
-      }
-
-      &:last-of-type {
-        width: 40%;
-      }
     }
+  }
+}
+
+@include media($lg) {
+  .totals-table__row--nested {
+    padding: u(1rem 4rem);
+    width: 50%;
+    float: left;
   }
 }

--- a/scss/modules/_totals-tables.scss
+++ b/scss/modules/_totals-tables.scss
@@ -52,8 +52,11 @@
 }
 
 .totals-table__header-data {
+  border-bottom: 1px solid $primary;
   font-size: u(2rem);
   font-weight: bold;
+  padding-bottom: u(1rem);
+  margin-bottom: u(2rem);
 }
 
 .totals-table__row--nested {


### PR DESCRIPTION
## Summary
- Adjusts the colors of the `.accordion--neutral` class based on designs in https://github.com/18F/fec-style/issues/315
- Adjusts the totals table rows to be half-width, with bars below the labels and numbers

## Screenshots
Totals tables on committee pages:
![image](https://cloud.githubusercontent.com/assets/1696495/16174623/9350845a-357f-11e6-92c6-dc0712232d33.png)

About buttons on landing page:
![image](https://cloud.githubusercontent.com/assets/1696495/16174630/db2f52e2-357f-11e6-9f54-1dc88bb7857c.png)




_cc @username_

