### PR TITLE
Tooltip adjustments

### DIFF
--- a/img/tooltip-point.svg
+++ b/img/tooltip-point.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="20px" height="10px" viewBox="0 0 20 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
+    <title>tooltip-point</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="tooltip-point">
+            <polygon id="Path-2" fill="#112E51" points="0 10 2.00851609 10 10.00819 10 17.9925609 10 20 10 10.00819 0"></polygon>
+            <polygon id="Triangle-2" fill="#FFFFFF" points="10 2.5 17.5 10 2.5 10"></polygon>
+        </g>
+    </g>
+</svg>

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -73,9 +73,10 @@
 }
 
 .tooltip--under {
+  $top: u(1rem);
   width: u(30rem);
-  right: u(-14rem);
-  top: u(3rem);
+  left: u(-14rem);
+  top: calc(100% + #{$top});
 
   &::before {
     background-image: url('../img/tooltip-point.svg');
@@ -83,12 +84,17 @@
     background-size: contain;
     content: '';
     display: block;
-    position: absolute;
+    height: u(2rem);
     left: 50%;
     margin-left: u(-1rem);
+    position: absolute;
     top: u(-1rem);
     width: u(2rem);
-    height: u(2rem);
+  }
+
+  &.tooltip--left {
+    left: auto;
+    right: u(-14rem);
   }
 }
 
@@ -97,8 +103,8 @@
 // For tooltips on regular DOM elements (rather than on maps) that contain additional info
 //
 // Markup:
+// <label class="label tooltip__trigger-text">Select something</label>
 // <div class="tooltip__container">
-//   <label class="label tooltip__trigger-text">Select something</label>
 //   <button class="tooltip__trigger"><span class="u-visually-hidden">Learn more</span></button>
 //   <div class="tooltip tooltip--under">
 //     <p class="tooltip__content">Learn more about this thing!</p>

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -73,24 +73,22 @@
 }
 
 .tooltip--under {
-  max-width: u(30rem);
+  width: u(30rem);
+  right: u(-14rem);
+  top: u(3rem);
 
   &::before {
-    @include triangle(2rem, $primary, up);
+    background-image: url('../img/tooltip-point.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
     content: '';
     display: block;
     position: absolute;
-    left: u(4rem);
+    left: 50%;
+    margin-left: u(-1rem);
     top: u(-1rem);
-  }
-
-  &::after {
-    @include triangle(1.6rem, $inverse, up);
-    content: '';
-    display: block;
-    position: absolute;
-    left: u(4.2rem);
-    top: u(-.7rem);
+    width: u(2rem);
+    height: u(2rem);
   }
 }
 
@@ -111,7 +109,11 @@
 // Styleguide components.tooltips.learn-more
 
 .tooltip__container {
-  display: block;
+  width: u(2rem);
+  height: u(2rem);
+  display: inline-block;
+  position: relative;
+  text-align: center;
 
   .tooltip__trigger-text {
     display: inline-block;
@@ -124,12 +126,11 @@
 
 .tooltip__trigger {
   @include u-icon-bg($info-circle-outline, $primary);
-  background-position: 100% 50%;
+  background-position: 50% 50%;
   background-size: contain;
   cursor: pointer;
   display: inline-block;
   height: 1.5em;
-  padding-right: 1.5em;
   vertical-align: middle;
   width: 1.5em;
 
@@ -170,7 +171,6 @@
 .tooltip--chart {
   display: none;
   position: absolute;
-  width: u(30rem);
 
   .tooltip__title {
     margin-bottom: u(1rem);

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -438,6 +438,10 @@
   border-color: $primary;
   padding: u(0 .5rem);
   border-radius: 3px;
+
+  .tooltip__trigger {
+    margin-top: -2px;
+  }
 }
 
 .cal-list__event-title {

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -218,11 +218,19 @@
 // Event details
 .cal-details {
   font-size: u(1.4rem);
+  left: auto;
+  top: auto;
   margin-top: u(1rem);
   padding: 0;
   text-align: left;
   width: u(26rem);
   white-space: initial;
+
+  &::before {
+    @include triangle(2rem, $primary, up);
+    background-image: none;
+    left: 20%;
+  }
 
   .button--close--primary {
     position: absolute;

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -564,6 +564,6 @@
   }
 
   .cal-list__category {
-    @include span-columns(2 of 10);
+    @include span-columns(3 of 10);
   }
 }


### PR DESCRIPTION
## Summary
Adjusts the way that tooltips should be marked up in order for them to be positioned more consistently and for the point to always be under the question mark trigger (if present). Specifically, the `.tooltip__container` class should now wrap the `.tooltip_trigger` and `.tooltip` only, not the text associated with the trigger as it previously was.

Along these lines, I replaced the CSS-generated arrow with an SVG, as in order to get the border effect on the CSS arrow we essentially had to overlap a blue and white triangle. For whatever reason, they would often be misaligned in some places but not others, and the simplest solution was to just make a static asset.

This also contains some minor spacing adjustments to the calendar list view. 