### PR TITLE
Using display:table-cell for height matching

### DIFF
--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -43,13 +43,6 @@ FilterPanel.prototype.setInitialDisplay = function() {
   }
 };
 
-FilterPanel.prototype.setHeight = function() {
-  if (helpers.getWindowWidth() >= helpers.BREAKPOINTS.LARGE &&
-      this.$dataContainer.height() > this.$body.height()) {
-    this.$body.css('min-height', this.$dataContainer.height());
-  }
-};
-
 FilterPanel.prototype.show = function() {
   this.$body.addClass('is-open').attr('aria-hidden', false);
   this.$toggle.attr('aria-hidden', true);

--- a/scss/modules/_data-container.scss
+++ b/scss/modules/_data-container.scss
@@ -61,13 +61,13 @@
 
 @include media($lg) {
   .data-container {
-    float: left;
     padding: 0;
   }
 
   .is-showing-filters {
     .data-container {
       width: calc(100% - 30rem);
+      display: table-cell;
     }
   }
 

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -33,7 +33,6 @@
     position: relative;
     left: 0;
     height: auto;
-    margin-left: 0%;
     padding: u(1rem 0);
 
     .filters__hider {
@@ -207,9 +206,9 @@
 
 @include media($lg) {
   .filters {
-    @include transition(margin-left .2s);
-    float: left;
-    margin-left: u(-30rem);
+    @include transition(left .2s ease-out);
+    display: table-cell;
+    left: u(-30rem);
     padding: u(2rem 0);
     position: relative;
     width: u(30rem);
@@ -217,6 +216,11 @@
 
     form {
       display: block;
+    }
+
+    &[aria-hidden="true"] {
+      display: table-cell !important;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
## Summary
This removes the JS that we were using to set the filter panel height in favor of using some old-school CSS `display: table-cell` magic. I can't remember if we had a good reason for not doing this earlier, but it seems to work just fine.

What do you think @adborden ?

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/16215776/a90706b6-3719-11e6-8dd3-2f8b0e9bd323.png)

Resolves https://github.com/18F/fec-cms/issues/319
