### PR TITLE
Hero style adjustment

### DIFF
--- a/scss/modules/_hero.scss
+++ b/scss/modules/_hero.scss
@@ -73,7 +73,7 @@
   padding-top: u(1rem);
 
   @include media($lg) {
-    @include span-columns(6);
+    @include span-columns(8);
   }
 }
 

--- a/scss/modules/_hero.scss
+++ b/scss/modules/_hero.scss
@@ -43,7 +43,7 @@
   background-repeat: no-repeat;
   background-position: 50% 0;
   background-size: cover;
-  height: u(4rem);
+  height: u(3rem);
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary

- Shortens image by 1rem to deprioritize it, and make it more textural
- Makes content container 3/4-width instead of 1/2

## Screenshots

<img width="1224" alt="screen shot 2016-06-22 at 10 11 56 am" src="https://cloud.githubusercontent.com/assets/11636908/16269898/44c60176-3862-11e6-971c-12486f52ac4a.png">

<img width="1223" alt="screen shot 2016-06-22 at 10 15 46 am" src="https://cloud.githubusercontent.com/assets/11636908/16269914/5552364a-3862-11e6-8e9c-394001585ed1.png">


Review: @noahmanger
This would be nice to get in with the release, but not mission critical