### PR TITLE
Adds operating expenditures

### DIFF
--- a/js/terms.json
+++ b/js/terms.json
@@ -148,6 +148,10 @@
     "term": "Party committee",
     "definition": "A political committee that represents a political party and is part of the official party structure at the national, state or local level. "
   },
+     {
+    "term": "Operating expenditures",
+    "definition": "A committee's day-to-day expenditures for items such as rent, overhead, administration, personnel, equipment, travel, advertising and fundraising."
+  },
   {
     "term": "Exempt party activities",
     "definition": "Certain candidate support activities that state and local party groups may undertake without making a contribution or expenditure, provided specific rules are followed."


### PR DESCRIPTION
Adds operating expenditures, which we'll want to have available when we launch the spending overview pages. This definition is approved by Amy K. and pulled directly from the campaign guide. 


_cc @jenniferthibault _

