### PR TITLE
Scale typeahead position offset in px

### DIFF
--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -118,7 +118,7 @@ $search-button-width: u(5.6rem);
 
     .tt-menu {
       font-size: u(1.6rem);
-      top: 5.9rem !important;
+      top: u(5.9rem) !important;
       width: calc(100% - 10.2rem);
     }
 
@@ -142,7 +142,7 @@ $search-button-width: u(5.6rem);
   left: 0;
   position: absolute;
   text-align: left;
-  top: 3.5rem !important;
+  top: u(3.5rem) !important;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
Scales the typeahead menu offsets in px for `fec-eregs`.

