### PR TITLE
Adding overflow-scroll to overview__methodology

### DIFF
--- a/scss/components/_accordions.scss
+++ b/scss/components/_accordions.scss
@@ -41,6 +41,7 @@
     &[aria-expanded='true'] {
       background-color: $gray-light;
       border-top: 1px solid $base;
+      border-bottom: 2px solid $gray;
     }
   }
 

--- a/scss/components/_overviews.scss
+++ b/scss/components/_overviews.scss
@@ -22,6 +22,16 @@
   }
 }
 
+.overview__methodology {
+  max-height: u(30rem);
+  overflow-y: scroll;
+
+  p,
+  li {
+    font-size: 1.4rem;
+  }
+}
+
 .top-list {
   border-style: solid;
   border-color: $base;


### PR DESCRIPTION
## Summary

Sets a fixed-height on the overview methodology accordions with `overflow-y: scroll`. Also adds border to the bottom of the accordion button when expanded.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/16285867/909b1142-388d-11e6-8eb2-722b9c1f1c71.png)

Goes with https://github.com/18F/openFEC-web-app/pull/1293

Cc @jenniferthibault 
