### PR TITLE
Re-sizes and positions the card icons

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -393,8 +393,8 @@
   @include u-icon-button($signal, left);
 }
 
-.button--cal {
-  @include u-icon-button($calendar, left);
+.button--grid {
+  @include u-icon-button($grid, left);
   height: u(3.4rem);
   width: u(9rem);
 }

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -278,16 +278,19 @@
   .card__icon {
     &.i-calendar {
       @include u-icon-bg($calendar, $secondary-contrast);
-      background-position: 60% 50%;
-      background-size: 40%;
+      background-position: 50% 50%;
+      background-size: 60%;
     }
 
     &.i-info-person {
       @include u-icon-bg($info-person, $secondary-contrast);
+      background-position: 50% 110%;
+      background-size: 100%;
     }
 
     &.i-training {
-      @include u-icon-bg($training, $primary-contrast);
+      @include u-icon-bg($training, $secondary-contrast);
+      background-size: 60%;
     }
   }
 }


### PR DESCRIPTION
## Summary
Re-sizes and re-positions the icons in the secondary cards on reporting and registration pages:
![image](https://cloud.githubusercontent.com/assets/1696495/16286549/037ef1b6-3892-11e6-8add-d53616fc286c.png)

Also renames the `.button--cal` class to `.button--grid` and uses a different icon for the grid-view toggle on the calendar page to avoid the conflict with the larger calendar icon used in cards.

cc @jenniferthibault 