### PR TITLE
Accessibility fixes

### DIFF
--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -67,6 +67,8 @@ TypeaheadFilter.prototype.typeaheadInit = function() {
   } else {
     this.$field.typeahead({minLength: 3}, this.dataset);
   }
+
+  this.$body.find('.tt-menu').attr('aria-live', 'polite');
 };
 
 TypeaheadFilter.prototype.setFirstItem = function() {

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -120,6 +120,10 @@ function Typeahead(selector, type, url) {
 
   this.init(type || 'candidates');
 
+  this.$element = this.$input.parent('.twitter-typeahead');
+  this.$element.css('display', 'block');
+  this.$element.find('.tt-menu').attr('aria-live', 'polite');
+
   events.on('searchTypeChanged', this.handleChangeEvent.bind(this));
 }
 
@@ -130,7 +134,6 @@ Typeahead.prototype.init = function(type) {
   this.dataset = datasets[type];
   this.typeahead = this.$input.typeahead(typeaheadOpts, this.dataset);
   this.$input.on('typeahead:select', this.select.bind(this));
-  $('.twitter-typeahead').css('display', 'block');
 };
 
 Typeahead.prototype.handleChangeEvent = function(data) {

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -525,3 +525,24 @@
     }
   }
 }
+
+.button--informative {
+  background-image: url('../img/reaction-informative.svg');
+  background-repeat: no-repeat;
+  background-position: u(1rem) 50%;
+  padding-left: u(4rem);
+}
+
+.button--confusing {
+  background-image: url('../img/reaction-confusing.svg');
+  background-repeat: no-repeat;
+  background-position: u(1rem) 50%;
+  padding-left: u(4rem);
+}
+
+.button--not-interested {
+  background-image: url('../img/reaction-not-interested.svg');
+  background-repeat: no-repeat;
+  background-position: u(1rem) 50%;
+  padding-left: u(4rem);
+}

--- a/scss/components/_figures.scss
+++ b/scss/components/_figures.scss
@@ -31,7 +31,11 @@
 }
 
 .figure__decimals {
-  color: $gray;
+  color: $gray-dark;
   font-weight: normal;
   letter-spacing: 3px;
+
+  &[aria-hidden="true"] {
+    display: inline !important;
+  }
 }

--- a/scss/components/_reaction-boxes.scss
+++ b/scss/components/_reaction-boxes.scss
@@ -36,44 +36,19 @@
   position: relative;
   overflow: hidden;
 
-  .reaction--informative {
-    background-image: url('../img/reaction-informative.svg');
-    background-repeat: no-repeat;
-    background-position: u(3rem) 50%;
-
-    &::before {
-      margin-right: u(3.5rem);
-    }
-  }
-
-  .reaction--confusing {
-    background-image: url('../img/reaction-confusing.svg');
-    background-repeat: no-repeat;
-    background-position: u(3rem) 50%;
-
-    &::before {
-      margin-right: u(3.5rem);
-    }
-  }
-
-  .reaction--not-interested {
-    background-image: url('../img/reaction-not-interested.svg');
-    background-repeat: no-repeat;
-    background-position: u(3rem) 50%;
-
-    &::before {
-      margin-right: u(3.5rem);
-    }
-  }
-
   textarea {
     height: u(11rem);
+    margin-bottom: u(1rem);
+  }
+
+  li {
     margin-bottom: u(1rem);
   }
 }
 
 .reaction-box__heading {
   @include u-icon-bg($question-circle, $primary);
+  display: block;
   font-size: u(1.6rem);
   font-weight: bold;
   line-height: 1.2;

--- a/scss/modules/_data-container.scss
+++ b/scss/modules/_data-container.scss
@@ -60,6 +60,11 @@
 // Data-container shrinks and floats
 
 @include media($lg) {
+  .data-container__wrapper {
+    display: table;
+    width: 100%;
+  }
+
   .data-container {
     padding: 0;
   }


### PR DESCRIPTION
## Summary
- Makes various small fixes based on @nickbristow 's latest [accessibility review](https://github.com/18F/Accessibility_Reviews/issues/15#issuecomment-228167208)
- Adds a `.datatable-container__wrapper` class to ensure that the new `display: table-cell` data-containers always take up the rest of the space on the screen.
- Refactors the reaction-box component to use `button` elements instead of radio buttons
