### PR TITLE
Datatable styles

### DIFF
--- a/js/sticky-bar.js
+++ b/js/sticky-bar.js
@@ -14,16 +14,16 @@ function StickyBar(selector) {
 }
 
 StickyBar.prototype.toggle = function() {
-  if (helpers.isLargeScreen()) {
-    var scrollTop = this.$body.scrollTop();
-    if (scrollTop >= this.offset + this.triggerOffset) {
-      var height = this.$bar.outerHeight();
-      this.$bar.addClass('is-stuck');
-      this.$body.css('padding-top', height);
-    } else if (scrollTop < this.offset) {
-      this.$bar.removeClass('is-stuck');
-      this.$body.css('padding-top', this.defaultBodyPadding);
-    }
+  if (!helpers.isLargeScreen()) { return; }
+
+  var scrollTop = this.$body.scrollTop();
+  if (scrollTop >= this.offset + this.triggerOffset) {
+    var height = this.$bar.outerHeight();
+    this.$bar.addClass('is-stuck');
+    this.$body.css('padding-top', height);
+  } else if (scrollTop < this.offset) {
+    this.$bar.removeClass('is-stuck');
+    this.$body.css('padding-top', this.defaultBodyPadding);
   }
 };
 

--- a/js/sticky-bar.js
+++ b/js/sticky-bar.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var $ = require('jquery');
+var helpers = require('./helpers');
 
 function StickyBar(selector) {
   this.$body = $('body');
@@ -13,14 +14,16 @@ function StickyBar(selector) {
 }
 
 StickyBar.prototype.toggle = function() {
-  var scrollTop = this.$body.scrollTop();
-  if (scrollTop >= this.offset + this.triggerOffset) {
-    var height = this.$bar.outerHeight();
-    this.$bar.addClass('is-stuck');
-    this.$body.css('padding-top', height);
-  } else if (scrollTop < this.offset) {
-    this.$bar.removeClass('is-stuck');
-    this.$body.css('padding-top', this.defaultBodyPadding);
+  if (helpers.isLargeScreen()) {
+    var scrollTop = this.$body.scrollTop();
+    if (scrollTop >= this.offset + this.triggerOffset) {
+      var height = this.$bar.outerHeight();
+      this.$bar.addClass('is-stuck');
+      this.$body.css('padding-top', height);
+    } else if (scrollTop < this.offset) {
+      this.$bar.removeClass('is-stuck');
+      this.$body.css('padding-top', this.defaultBodyPadding);
+    }
   }
 };
 

--- a/js/templates/mobile-nav.hbs
+++ b/js/templates/mobile-nav.hbs
@@ -87,7 +87,7 @@
 
 <div id="nav-advanced-spending" class="site-nav__panel site-nav__panel--sub" aria-hidden="true">
   <button class="site-nav__back button--back button--alt-primary js-panel-close" aria-controls="nav-advanced-spending">Advanced data</button>
-  <h3 class="site-nav__title"><a class="site-nav__link--underline" href="{{webAppUrl}}/receipts/?is_individual=true&max_date={{today}}">Spending</a></h3>
+  <h3 class="site-nav__title">Spending</h3>
   <ul>
     <li class="site-nav__item site-nav__item--sub"><a class="site-nav__link" href="{{webAppUrl}}/disbursements/?max_date={{today}}">All disbursements</a></li>
     <li class="site-nav__item site-nav__item--sub is-disabled"><a class="site-nav__link">Operating expenditures</a></li>

--- a/scss/components/_stickybar.scss
+++ b/scss/components/_stickybar.scss
@@ -7,24 +7,25 @@
 //
 // Styleguide components.sticky-bar
 
-.sticky-bar {
-  // @include transition(top .4s ease-out);
-  z-index: $z-sticky;
-  width: 100%;
+@include media($lg) {
+  .sticky-bar {
+    z-index: $z-sticky;
+    width: 100%;
 
-  // To stick to the top of the page
-  &.is-stuck {
-    position: fixed;
-    top: 0;
-    left: 0;
-  }
-
-  &.with-transition {
-    @include transition(top .4s ease-out);
-    top: -200px; // Setting this property so we can animate it when .is-stuck is applied
-
+    // To stick to the top of the page
     &.is-stuck {
+      position: fixed;
       top: 0;
+      left: 0;
+    }
+
+    &.with-transition {
+      @include transition(top .4s ease-out);
+      top: -200px; // Setting this property so we can animate it when .is-stuck is applied
+
+      &.is-stuck {
+        top: 0;
+      }
     }
   }
 }

--- a/scss/modules/_datatable-panel.scss
+++ b/scss/modules/_datatable-panel.scss
@@ -3,8 +3,7 @@
 // Styleguide modules.datatable-panel
 
 .panel__main {
-  @include transform(translate3D(0%, 0, 0));
-  @include transition(left .2s ease-in);
+  @include clearfix();
   left: 0;
   clear: both;
   position: relative;
@@ -167,6 +166,10 @@
   .panel-active {
     .panel__main {
       max-height: 100%;
+      position: relative;
+    }
+
+    .data-table {
       position: relative;
     }
   }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -122,7 +122,7 @@
     padding: u(1rem);
     border-left: 1px solid $neutral;
 
-    &.currency-column {
+    &.column--number {
       text-align: right;
     }
 
@@ -264,5 +264,27 @@
 
   .cell--#{$width} {
     @include cell-width($width);
+  }
+}
+
+.column--small {
+  width: 80px;
+}
+
+.column--med {
+  width: 15%;
+}
+
+.column--large {
+  width: 20%;
+}
+
+.column--xl {
+  width: 30%;
+}
+
+.panel-active {
+  .column--xl {
+    width: 50%;
   }
 }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -104,8 +104,7 @@
     }
 
     &.column--trigger {
-      width: 30px;
-      padding: 0;
+      width: 40px;
       text-align: center;
       border-left: none;
     }
@@ -136,10 +135,9 @@
     }
 
     &.column--trigger {
-      width: 30px;
-      padding: 0;
+      width: 40px;
+      padding: 0 u(1rem);
       text-align: center;
-      border-left: none;
     }
 
     &.no-wrap {
@@ -169,7 +167,6 @@
 
   // Special styles for tables that use `offsetX: true`
   &.scrollX {
-    border-collapse: separate;
     table-layout: auto;
   }
 }
@@ -283,6 +280,10 @@
 }
 
 @include media($med) {
+  .column--state {
+    width: 50px;
+  }
+
   .column--small {
     width: 90px;
   }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -90,15 +90,23 @@
     &.sorting_asc {
       @include u-icon-bg($arrow-up-border, $primary);
       background-size: u(1rem);
+      background-color: $gray-lightest;
     }
 
     &.sorting_desc {
       @include u-icon-bg($arrow-down-border, $primary);
       background-size: u(1rem);
+      background-color: $gray-lightest;
     }
 
-    &:last-child,
     &:first-child {
+      border-left: none;
+    }
+
+    &.column--trigger {
+      width: 30px;
+      padding: 0;
+      text-align: center;
       border-left: none;
     }
   }
@@ -120,17 +128,24 @@
   td {
     @include transition(padding-left, .2s);
     padding: u(1rem);
+    overflow: hidden;
     border-left: 1px solid $neutral;
 
     &.column--number {
       text-align: right;
     }
 
+    &.column--trigger {
+      width: 30px;
+      padding: 0;
+      text-align: center;
+      border-left: none;
+    }
+
     &.no-wrap {
       white-space: nowrap;
     }
 
-    &:last-child,
     &:first-child {
       border-left: none;
     }
@@ -267,24 +282,37 @@
   }
 }
 
-.column--small {
-  width: 80px;
-}
+@include media($med) {
+  .column--small {
+    width: 90px;
+  }
 
-.column--med {
-  width: 15%;
-}
+  .column--med {
+    width: 15%;
+  }
 
-.column--large {
-  width: 20%;
-}
+  .column--large {
+    width: 20%;
+  }
 
-.column--xl {
-  width: 30%;
-}
-
-.panel-active {
   .column--xl {
-    width: 50%;
+    width: 30%;
+  }
+
+  .panel-active {
+    .column--xl,
+    .column--large {
+      width: 50%;
+    }
+
+    .column--med {
+      width: 25%;
+    }
+  }
+}
+
+@include media($lg) {
+  .column--med {
+    width: 12%;
   }
 }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -71,14 +71,15 @@
     letter-spacing: -.3px;
     padding: u(.5rem 1rem);
     border-bottom: 1px solid $primary;
+    border-left: 1px solid $neutral;
 
     &.sorting,
     &.sorting_asc,
     &.sorting_desc {
-      background-position: 0 50%;
+      background-position: calc(100% - 1rem) 50%;
       background-repeat: no-repeat;
       cursor: pointer;
-      padding-left: u(2rem);
+      padding-right: u(2rem);
     }
 
     &.sorting {
@@ -95,12 +96,21 @@
       @include u-icon-bg($arrow-down-border, $primary);
       background-size: u(1rem);
     }
+
+    &:last-child,
+    &:first-child {
+      border-left: none;
+    }
   }
 
   tr {
     border-left-width: 0;
     background-color: $inverse;
     border-bottom: 1px solid $neutral;
+
+    &:nth-child(even) {
+      background-color: rgba($gray-lightest, .5);
+    }
 
     &.row-active {
       border-left: .5rem solid $primary;
@@ -109,8 +119,21 @@
 
   td {
     @include transition(padding-left, .2s);
-    @include u-truncate();
     padding: u(1rem);
+    border-left: 1px solid $neutral;
+
+    &.currency-column {
+      text-align: right;
+    }
+
+    &.no-wrap {
+      white-space: nowrap;
+    }
+
+    &:last-child,
+    &:first-child {
+      border-left: none;
+    }
   }
 
   .sorting_disabled {
@@ -125,8 +148,7 @@
   @include media($lg) {
     th,
     td {
-      padding-left: u(2rem);
-      padding-right: u(1rem);
+      padding: u(1rem);
     }
   }
 
@@ -184,15 +206,6 @@
     position: absolute;
     top: 50%;
     width: u(1rem);
-  }
-}
-
-// For wrapping long table cells instead of truncating
-.data-table--wrapped {
-  td {
-    white-space: pre-wrap;
-    text-overflow: ellipsis;
-    overflow: visible;
   }
 }
 

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -206,7 +206,6 @@
 
 @include media($lg) {
   .filters {
-    @include transition(left .2s ease-out);
     display: table-cell;
     left: u(-30rem);
     padding: u(2rem 0);

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -132,10 +132,11 @@
   width: 100%;
 
   @include media($med) {
-    @include u-background-image('wordmark', 0% 50%);
+    @include u-background-image('wordmark', u(12rem) 50%);
     background-size: contain;
     display: block;
-    margin: u(1rem 0 .7rem 12rem);
+    margin: u(1rem 0 .7rem 0);
+    padding-left: u(12rem);
     height: u(3.4rem);
     width: 100%;
   }


### PR DESCRIPTION
## Summary
This introduces a few data table style changes, namely:
- Tiger-striped table cells
- Right border on data table cells
- Doesn't stick the sticky bar on small screens
- A new `.column--number` class that right-aligns columns with numbers (dates and money)
- New size classes for data-table columns to control the sizing in CSS rather than in the JS that defines each table

I'll post screenshots after things have settled. Still a WIP.