### PR TITLE
Styleguide fixes

### DIFF
--- a/fec-template/templates/billboard.hbs
+++ b/fec-template/templates/billboard.hbs
@@ -1,6 +1,6 @@
 <div class="billboard">
   <div class="billboard__image__container">
-    <img class="billboard__image" src="../img/api@2x.png" alt="API documentation screenshot">
+    <img class="billboard__image" src="img/api@2x.png" alt="API documentation screenshot">
   </div>
   <div class="billboard__content">
     <h2 class="feature__title">The FEC API: Use our data in your project</h2>

--- a/fec-template/templates/cards.hbs
+++ b/fec-template/templates/cards.hbs
@@ -4,7 +4,7 @@
       {{#renderChild 'card--primary' 'card--neutral' 'card--secondary' 'card--secondary-contrast'}}
         <aside class="grid__item card {{className}}">
           <div class="card__image__container">
-            <img alt="" src="../img/i-calendar--primary.svg" class="icon--complex card__image">
+            <img alt="" src="img/i-calendar--primary.svg" class="icon--complex card__image">
           </div>
           <div class="card__content">
             <a href="#">Take this action</a>
@@ -18,7 +18,7 @@
       {{#renderChild 'card--primary' 'card--neutral' 'card--secondary' 'card--secondary-contrast'}}
         <aside class="grid__item card card--horizontal {{className}}">
           <div class="card__image__container">
-            <img alt="" src="../img/i-calendar--primary.svg" class="icon--complex card__image">
+            <img alt="" src="img/i-calendar--primary.svg" class="icon--complex card__image">
           </div>
           <div class="card__content">
             <a href="#">Take this action</a>
@@ -32,7 +32,7 @@
       {{#renderChild 'card--primary' 'card--neutral' 'card--secondary' 'card--secondary-contrast'}}
         <aside class="grid__item card card--horizontal card--full-bleed {{className}}">
           <div class="card__image__container">
-            <img alt="" src="../img/i-calendar--primary.svg" class="icon--complex card__image">
+            <img alt="" src="img/i-calendar--primary.svg" class="icon--complex card__image">
           </div>
           <div class="card__content">
             <a href="#">Take this action</a>
@@ -45,7 +45,7 @@
     <div class="grid grid--2-wide">
       <aside class="grid__item card card--horizontal card--wide">
         <div class="card__image__container">
-          <img alt="" src="../img/i-calendar--primary.svg" class="icon--complex card__image">
+          <img alt="" src="img/i-calendar--primary.svg" class="icon--complex card__image">
         </div>
         <div class="card__content">
           <h2 class="card__title">Committee data</h2>

--- a/scss/components/_messages.scss
+++ b/scss/components/_messages.scss
@@ -14,7 +14,7 @@
 //   <p>This entity has no financial data for the 2011-2012 election cycle in OpenFEC.</p>
 //   <p>For complete data, search the <a href="http://www.fec.gov/finance/disclosure/candcmte_info.shtml">FEC Candidate and Committee Viewer</a>.</p>
 //   <div class="message--alert__bottom">
-//       <h4>Is this information incorrect? Let us know.</h4>
+//       <p>Is this information incorrect? Let us know.</p>
 //       <a class="button button--standard" href="mailto:{{ contact_email }}">Contact support <i class="ti-email"></i></a>
 //   </div>
 // </div>

--- a/scss/modules/_footer.scss
+++ b/scss/modules/_footer.scss
@@ -4,7 +4,7 @@
 // <footer class="footer">
 //   <div class="container">
 //     <div class="seal">
-//       <img class="seal__img"src="../img/seal--reversed@2x.png" alt="Seal of the Federal Election Commission">
+//       <img class="seal__img" src="img/seal--reversed@2x.png" alt="Seal of the Federal Election Commission">
 //     </div>
 //     <div class="address">
 //       <p class="address__title">Federal Election Commission</p>

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -43,7 +43,7 @@
 //   <span class="disclaimer__left">This site is in beta, visit <a href="http://www.fec.gov">FEC.gov</a></span>
 //   <span class="disclaimer__right">
 //     An official website of the United States Government.
-//     <img alt="US flag signifying that this is a United States Federal Government website" src="../img/us_flag_small.png">
+//     <img alt="US flag signifying that this is a United States Federal Government website" src="img/us_flag_small.png">
 //   </span>
 // </div>
 //


### PR DESCRIPTION
## Summary
- Fixes an issue where certain images weren't being found in the generated style guide (resolves https://github.com/18F/fec-style/issues/363)
- Fixes an issue where the example message markup on the styleguide incorrectly used an `h4`, creating incorrect padding. Elsewhere on the site, we just use `p` tags instead. (Resolves https://github.com/18F/fec-style/issues/364)

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/16473926/07f71508-3e27-11e6-8d62-450315d09f60.png)

cc @adborden 
