### PR TITLE
Fixing analytics

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -5,15 +5,26 @@
 var URI = require('urijs');
 var _ = require('underscore');
 
-function init() {
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+function trackerExists() {
+  if (typeof ga !== 'undefined') {
+    return true;
+  }
+}
 
-  ga('set', 'forceSSL', true);
-  ga('set', 'anonymizeIp', true);
-  ga('create', 'UA-48605964-22', 'auto');
+/* Initialize a non Digital Analytics Program GA tracker
+ * This tracker's name is "nonDAP", so all commands will need to be prefixed
+*/
+function init() {
+  if (!trackerExists) {
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  }
+
+  ga('create', 'UA-48605964-22', 'auto', 'notDAP');
+  ga('notDAP.set', 'forceSSL', true);
+  ga('notDAP.set', 'anonymizeIp', true);
 }
 
 function pageView() {
@@ -23,7 +34,7 @@ function pageView() {
     var query = URI.parseQuery(document.location.search);
     path += '?' + sortQuery(query);
   }
-  ga('send', 'pageview', path);
+  ga('notDAP.send', 'pageview', path);
 }
 
 function sortQuery(query) {
@@ -47,6 +58,7 @@ function sortQuery(query) {
 
 module.exports = {
   init: init,
+  pageView: pageView,
   sortQuery: sortQuery,
-  pageView: pageView
+  trackerExists: trackerExists
 };


### PR DESCRIPTION
This addresses a problem caused by the fact that we have two Google Analytics trackers on the site (one for the Digital Analytics Program and one for non-DAP GA) where custom events that didn't have a tracker specified would throw an error and our analytics would not register custom events.

So this addresses it by:
- Only adding the GA script if it hasn't already been added by DAP
- Adding a name (`nonDAP`) to the non-DAP tracker
- Calling `set` and `send` with the new namespaced tracker

This goes with a companion PR on the web app https://github.com/18F/openFEC-web-app/pull/1339 .

I'd like @gbinal 's eyes on this if you have time and maybe @jmcarp, who originally set up the analytics code on the project. 

It definitely solved the problem, but I want to make sure I'm not inadvertently breaking something else. Using the GA Debugger for Chrome it looks like the DAP events are still being sent and everything, but I just want to be safe.

