### PR TITLE
Prevent logo from being cut off

### DIFF
--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -144,7 +144,7 @@
   }
 
   @include media($lg) {
-    width: 32%;
+    width: 50%;
   }
 }
 


### PR DESCRIPTION
## Summary
Sets a wider width on `.site-title` so it doesn't get cut off when the screen is between a tablet and 960px.

cc @adborden 
