### PR TITLE
Adding a slight delay to the nav opening

### DIFF
--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -79,6 +79,7 @@ SiteNav.prototype.initMegaMenu = function() {
     hoverClass: 'is-hover',
     focusClass: 'is-focus',
     openClass: 'is-open',
+    openDelay: 350,
     selectors: {
       topNavItems: '[data-submenu]'
     }

--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -79,7 +79,7 @@ SiteNav.prototype.initMegaMenu = function() {
     hoverClass: 'is-hover',
     focusClass: 'is-focus',
     openClass: 'is-open',
-    openDelay: 350,
+    openDelay: 500,
     selectors: {
       topNavItems: '[data-submenu]'
     }


### PR DESCRIPTION
## Summary

I discovered a PR to the accessible mega menu library that someone made but which never got merged in that adds the ability to define a delay to the opening of the mega menu. I tried it out and have it queued up as a PR into my fork: https://github.com/noahmanger/Accessible-Mega-Menu/pull/1

This PR just makes use of that param. I know we're still tinkering with the concept of the mega menu, but this seems like a nice UI tweak to make in the mean time. 

What do you think @jenniferthibault @onezerojeremy (for UX) and @adborden ?

