### PR TITLE
Filter accessibility

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -6,8 +6,6 @@ var URI = require('urijs');
 
 var Filter = require('./filters').Filter;
 
-var KEYCODE_ENTER = 13;
-
 function FilterSet(elm) {
   this.$body = $(elm);
   $(document.body).on('tag:removed', this.handleTagRemove.bind(this));

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -39,7 +39,7 @@ FilterSet.prototype.activate = function() {
 };
 
 FilterSet.prototype.serialize = function() {
-  return _.reduce(this.$body.serializeArray(), function(memo, val) {
+  return _.reduce(this.$body.find('input,select').serializeArray(), function(memo, val) {
     if (val.value && val.name.slice(0, 1) !== '_') {
       if (memo[val.name]) {
         memo[val.name].push(val.value);

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -61,11 +61,11 @@ var TypeaheadFilter = function(selector, dataset, allowText) {
 
 TypeaheadFilter.prototype.typeaheadInit = function() {
   if (this.allowText && this.dataset) {
-    this.$field.typeahead({minLength: 3}, textDataset, this.dataset);
+    this.$field.typeahead({minLength: 3, hint: false}, textDataset, this.dataset);
   } else if (this.allowText && !this.dataset) {
-    this.$field.typeahead({minLength: 1}, textDataset);
+    this.$field.typeahead({minLength: 1, hint: false}, textDataset);
   } else {
-    this.$field.typeahead({minLength: 3}, this.dataset);
+    this.$field.typeahead({minLength: 3, hint: false}, this.dataset);
   }
 
   this.$body.find('.tt-menu').attr('aria-live', 'polite');

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -60,12 +60,13 @@ var TypeaheadFilter = function(selector, dataset, allowText) {
 };
 
 TypeaheadFilter.prototype.typeaheadInit = function() {
+  var opts = {minLength: 3, hint: false, highlight: true};
   if (this.allowText && this.dataset) {
-    this.$field.typeahead({minLength: 3, hint: false}, textDataset, this.dataset);
+    this.$field.typeahead(opts, textDataset, this.dataset);
   } else if (this.allowText && !this.dataset) {
-    this.$field.typeahead({minLength: 1, hint: false}, textDataset);
+    this.$field.typeahead(opts, textDataset);
   } else {
-    this.$field.typeahead({minLength: 3, hint: false}, this.dataset);
+    this.$field.typeahead(opts, this.dataset);
   }
 
   this.$body.find('.tt-menu').attr('aria-live', 'polite');

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -205,6 +205,10 @@ $search-button-width: u(5.6rem);
   border-bottom: 1px solid $base;
 }
 
+.tt-highlight {
+  background-color: rgba($aqua, .3);
+}
+
 // Specific styles for typeahead filters
 // Just testing things out. Refactor to use non-js class if we use it
 .js-typeahead-filter {


### PR DESCRIPTION
## Summary
Makes a couple changes to fix some accessibility issues with our filters:

Disables "hints" on the typeahead filters. We weren't using these in any of the other typeahead search fields, and they were posing a minor accessibility issue as it entailed adding an input on top of the input where you were entering text, but this input was both a keyboard focus trap and also lacked a proper label. So instead of this:
![image](https://cloud.githubusercontent.com/assets/1696495/16704117/5056688c-4528-11e6-837e-b51fa101b3e5.png)

We'll have this:
![image](https://cloud.githubusercontent.com/assets/1696495/16704120/5df7d8cc-4528-11e6-8803-6e914e67cfd3.png)

It also accomodates changes coming on the web app and cms where `<form>` elements that wrapped the filters are replaced with `<div>`s, since there's no submit button. This required a change to the `filterSet` component to have `serializeArray()` called on the individual elements themselves, rather than the `form`, since it cannot be called on a `div`.

Resolves https://github.com/18F/openFEC-web-app/issues/1310
Resolves https://github.com/18F/openFEC-web-app/issues/958