### PR TITLE
Filter tab bug

### DIFF
--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -14,7 +14,7 @@ var BODY_TEMPLATE = _.template(
 );
 
 var TAG_TEMPLATE = _.template(
-  '<li data-id="{{ key }}" class="tag">' +
+  '<li data-id="{{ key }}" data-removable="true" class="tag">' +
     '{{ value }}' +
     '<button class="button js-close tag__remove">' +
       '<span class="u-visually-hidden">Remove</span>' +
@@ -52,7 +52,9 @@ TagList.prototype.addTag = function(e, opts) {
   this.removeTag(opts.key, false);
   this.$title.html('');
   this.$list.append(tag);
-  this.$clear.attr('aria-hidden', false);
+  if (!opts.nonremovable) {
+    this.$clear.attr('aria-hidden', false);
+  }
 };
 
 TagList.prototype.removeTag = function(key, emit) {
@@ -64,15 +66,18 @@ TagList.prototype.removeTag = function(key, emit) {
     $tag.remove();
   }
 
+  if (this.$list.find('.tag[data-removable]').length === 0) {
+    this.$clear.attr('aria-hidden', true);
+  }
+
   if (this.$list.find('.tag').length === 0) {
     this.$title.html(this.opts.title);
-    this.$clear.attr('aria-hidden', true);
   }
 };
 
 TagList.prototype.removeAllTags = function(e) {
   var self = this;
-  this.$list.find('[data-id]').each(function(){
+  this.$list.find('[data-removable]').each(function(){
     self.removeTag($(this).data('id'), true);
   });
 };

--- a/js/filters.js
+++ b/js/filters.js
@@ -136,6 +136,7 @@ function SelectFilter(elm) {
   this.$input = this.$body.find('select');
   this.name = this.$input.attr('name');
   this.requiredDefault = this.$body.data('required-default') || null; // If a default is required
+  this.$input.on('change', this.handleChange.bind(this));
   this.setRequiredDefault();
 }
 
@@ -156,6 +157,19 @@ SelectFilter.prototype.setValue = function(value) {
   this.$input.find('option[selected]').attr('selected','false');
   this.$input.find('option[value="' + value + '"]').attr('selected','true');
   this.$input.change();
+};
+
+SelectFilter.prototype.handleChange = function(e) {
+  var value = $(e.target).val();
+  var id = this.$input.attr('id');
+
+  this.$input.trigger('filter:added', [
+    {
+      key: id,
+      value: 'Transaction period: ' + (value - 1) + '-' + value,
+      nonremovable: true
+    }
+  ]);
 };
 
 function DateFilter(elm) {


### PR DESCRIPTION
## Summary
- Only show the "Clear all filters" button if the tags are removable. That way, in cases where certain filters are applied by default and not removable, it doesn't give the option to remove them.
- Adds a non-removable filter tag for "transaction period" that follows this logic

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1696495/16932601/335fbedc-4cfc-11e6-8f8c-7965eb175a72.png)

Resolves https://github.com/18F/openFEC-web-app/issues/1311

cc @xtine 