### PR TITLE
Capitalization fix

### DIFF
--- a/js/terms.json
+++ b/js/terms.json
@@ -13,7 +13,7 @@
   },
   {
     "term": "District",
-    "definition": "A U.S. House of Representatives District. Because Senators represent an entire state, Senate races do not have districts associated with them."
+    "definition": "A U.S. House of Representatives District. Because senators represent an entire state, Senate races do not have districts associated with them."
   },
   {
     "term": "Organization type",


### PR DESCRIPTION
Senators shouldn't be capitalized unless as a title preceding a name.

Content only.