### PR TITLE
Full-height filter panel on mobile

### DIFF
--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -43,13 +43,17 @@ FilterPanel.prototype.setInitialDisplay = function() {
   }
 };
 
-FilterPanel.prototype.show = function() {
+FilterPanel.prototype.show = function(focus) {
   this.$body.addClass('is-open').attr('aria-hidden', false);
   this.$toggle.attr('aria-hidden', true);
   accessibility.restoreTabindex(this.$form);
   $('body').addClass('is-showing-filters');
   this.isOpen = true;
-  this.$body.find('input').first().focus();
+  // Don't focus on the first filter unless explicitly intended to
+  // Prevents the first filter from being focused on initial page load
+  if (focus) {
+    this.$body.find('input, select, button:not(.js-filter-close)').first().focus();
+  }
 };
 
 FilterPanel.prototype.hide = function() {
@@ -65,7 +69,7 @@ FilterPanel.prototype.toggle = function() {
   if (this.isOpen) {
     this.hide();
   } else {
-    this.show();
+    this.show(true);
   }
 };
 

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -49,7 +49,7 @@ FilterPanel.prototype.show = function() {
   accessibility.restoreTabindex(this.$form);
   $('body').addClass('is-showing-filters');
   this.isOpen = true;
-  this.$close.focus();
+  this.$body.find('input').first().focus();
 };
 
 FilterPanel.prototype.hide = function() {

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -30,8 +30,10 @@
 
   // Styles for when the filters are open
   &.is-open {
-    position: relative;
+    position: absolute;
+    top: -20px;
     left: 0;
+    z-index: 10;
     height: auto;
     padding: u(1rem 0);
 
@@ -220,6 +222,12 @@
     &[aria-hidden="true"] {
       display: table-cell !important;
       padding: 0;
+    }
+
+    &.is-open {
+      position: relative;
+      top: 0;
+      z-index: 0;
     }
   }
 

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -24,23 +24,24 @@
 .filters {
   @include clearfix();
   @include u-bg--neutral();
-  @include transition(top 1s ease-in-out);
+  @include transition(left 1s ease-in-out);
   position: absolute;
   bottom: 0;
   height: auto;
-  top: -1500px;
+  top: -20px;
+  left: -800px;
   z-index: 10;
   width: 100%;
   padding: u(1rem 0);
-  display: table;
+  display: block;
 
   // slide filters down into view when open
   &.is-open {
-    top: -20px;
+    left: 0;
   }
 
   &[aria-hidden=true] {
-    display: table !important;
+    display: block !important;
   }
 
   .filters__hider {
@@ -226,7 +227,7 @@
     }
 
     &[aria-hidden="true"] {
-      padding: 0;
+      display: none !important;
     }
 
     &.is-open {

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -24,13 +24,13 @@
 .filters {
   @include clearfix();
   @include u-bg--neutral();
-  @include transition(left 1s ease-in-out);
+  @include transition(left .2s ease-in-out);
   position: absolute;
   bottom: 0;
   height: auto;
-  top: -20px;
+  top: u(-2rem);
   left: -800px;
-  z-index: 10;
+  z-index: $z4;
   width: 100%;
   padding: u(1rem 0);
   display: block;

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -45,6 +45,7 @@
   }
 
   .filters__hider {
+    @include u-bg--neutral();
     height: auto;
     overflow: visible;
   }

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -20,27 +20,32 @@
 //
 // Styleguide modules.filters
 
+// by default show filters offscreen
 .filters {
   @include clearfix();
   @include u-bg--neutral();
+  @include transition(top 1s ease-in-out);
+  position: absolute;
   bottom: 0;
-  height: 0;
-  top: 0;
+  height: auto;
+  top: -1500px;
+  z-index: 10;
   width: 100%;
+  padding: u(1rem 0);
+  display: table;
 
-  // Styles for when the filters are open
+  // slide filters down into view when open
   &.is-open {
-    position: absolute;
     top: -20px;
-    left: 0;
-    z-index: 10;
-    height: auto;
-    padding: u(1rem 0);
+  }
 
-    .filters__hider {
-      height: auto;
-      overflow: visible;
-    }
+  &[aria-hidden=true] {
+    display: table !important;
+  }
+
+  .filters__hider {
+    height: auto;
+    overflow: visible;
   }
 
   .accordion__button {
@@ -208,6 +213,7 @@
 
 @include media($lg) {
   .filters {
+    @include transition(unset);
     display: table-cell;
     left: u(-30rem);
     padding: u(2rem 0);
@@ -227,6 +233,7 @@
     &.is-open {
       position: relative;
       top: 0;
+      left: 0;
       z-index: 0;
     }
   }


### PR DESCRIPTION
## Summary
- Changed filter panel to slide from the left over data table in mobile.

## Screenshots
![t3sn2ydqz1](https://cloud.githubusercontent.com/assets/24054/17191625/9bbf4632-53ff-11e6-9552-855e4bc78bc6.gif)

18F/openFEC-web-app#1326

/cc @noahmanger @jenniferthibault 

