### PR TITLE
Show number of applied filters on accordion heading

### DIFF
--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -53,6 +53,18 @@ TagList.prototype.addTag = function(e, opts) {
   this.$title.html('');
   this.$list.append(tag);
   this.$clear.attr('aria-hidden', false);
+
+  // increment applied filter count
+  var filterLabel = $(e.target).closest('.accordion__content').prev();
+  var filterCount = filterLabel.find('.filter-count');
+
+  if (filterCount.html()) {
+    filterCount.html(parseInt(filterCount.html(), 10) + 1);
+  }
+  else {
+    filterLabel.append(' <span class="filter-count">1</span>');
+  }
+  // TODO: write unit test
 };
 
 TagList.prototype.removeTag = function(key, emit) {
@@ -62,6 +74,17 @@ TagList.prototype.removeTag = function(key, emit) {
       $tag.trigger('tag:removed', [{key: key}]);
     }
     $tag.remove();
+
+    // decrement applied filter count
+    var filterCount = $('#' + key).closest('.accordion__content').prev().find('.filter-count');
+
+    if (filterCount.html() === '1') {
+      filterCount.remove();
+    }
+    else {
+      filterCount.html(parseInt(filterCount.html(), 10) - 1);
+    }
+    // TODO: write unit test
   }
 
   if (this.$list.find('.tag').length === 0) {

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -46,6 +46,14 @@
     padding-right: u(5rem);
   }
 
+  .filter-count::before {
+    content: '(';
+  }
+
+  .filter-count::after {
+    content: ')';
+  }
+
   .accordion__content {
     padding: u(2rem 2rem 1rem 2rem);
   }


### PR DESCRIPTION
## Summary
On filter accordion headings:
- shows number of applied filters upon load
- when a filter is applied, number increases by 1
- when a filter is removed, number decreases by 1
- when there are no filters, no numbers are shown.

Needs tests.

18F/openFEC-web-app#1327

## Screenshots
![mr5zzvvolb](https://cloud.githubusercontent.com/assets/24054/17197898/7ff68a20-5425-11e6-9f3e-3a43d0358066.gif)

/cc @noahmanger 