### PR TITLE
Data landing mobile

### DIFF
--- a/scss/components/_overviews.scss
+++ b/scss/components/_overviews.scss
@@ -52,6 +52,23 @@
   margin-bottom: u(.5rem);
 }
 
+@include media($med) {
+  .overview__totals {
+    @include span-columns(4);
+    padding-right: u(2rem);
+  }
+
+  .overview__chart {
+    @include span-columns(8);
+    @include omega();
+  }
+
+  .overview__feedback {
+    width: 100%;
+    clear: both;
+  }
+}
+
 @include media($lg) {
   .overview__totals {
     @include span-columns(3);
@@ -64,6 +81,7 @@
 
   .overview__feedback {
     @include span-columns(3);
+    clear: none;
   }
 
   .top-list {

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -181,4 +181,19 @@
   .tooltip__title {
     margin-bottom: u(1rem);
   }
+
+  .tooltip__point {
+    background-image: url('../img/tooltip-point.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
+    content: '';
+    display: block;
+    height: u(2rem);
+    left: 50%;
+    margin-left: u(-1rem);
+    position: absolute;
+    top: u(-1rem);
+    width: u(2rem);
+
+  }
 }

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -186,7 +186,6 @@
     background-image: url('../img/tooltip-point.svg');
     background-repeat: no-repeat;
     background-size: contain;
-    content: '';
     display: block;
     height: u(2rem);
     left: 50%;
@@ -194,6 +193,5 @@
     position: absolute;
     top: u(-1rem);
     width: u(2rem);
-
   }
 }


### PR DESCRIPTION
## Summary
- Adds separate styles for the data landing page chart and totals for medium-sized screens, so they're next to each other like they are on desktop
- Adds separate styles for when the tooltip point is it's own element, rather than a psuedo-element, which is useful for positioning it with javascript
 
