### PR TITLE
Calendar tooltips

### DIFF
--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -48,6 +48,10 @@
     border-bottom-color: $primary;
     color: $primary;
   }
+
+  li {
+    font-size: u(1.4rem);
+  }
 }
 
 .tooltip--above {

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -433,15 +433,30 @@
 }
 
 .cal-list__category-title {
-  display: inline-block;
+  @include clearfix();
+  display: table;
   border: 1px solid;
   border-color: $primary;
   font-size: u(1.4rem);
   padding: u(2px .5rem);
   border-radius: 3px;
 
-  .tooltip__trigger {
-    margin-top: -2px;
+  .tooltip__trigger-text {
+    border-right: 1px solid $primary;
+    display: table-cell;
+    padding-right: .5rem;
+    line-height: 1.2;
+    vertical-align: middle;
+  }
+
+  .tooltip__container {
+    display: table-cell;
+    vertical-align: middle;
+    padding-left: .5rem;
+  }
+
+  .list--bulleted li:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -436,7 +436,8 @@
   display: inline-block;
   border: 1px solid;
   border-color: $primary;
-  padding: u(0 .5rem);
+  font-size: u(1.4rem);
+  padding: u(2px .5rem);
   border-radius: 3px;
 
   .tooltip__trigger {

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -438,7 +438,7 @@
   border: 1px solid;
   border-color: $primary;
   font-size: u(1.4rem);
-  padding: u(2px .5rem);
+  padding: u(.5rem);
   border-radius: 3px;
 
   .tooltip__trigger-text {


### PR DESCRIPTION
## Summary
Styles the calendar category tooltips like so:

![image](https://cloud.githubusercontent.com/assets/1696495/17301854/0b94440e-57ce-11e6-84b0-8cfa489b6fc2.png)

I totally forgot to file a PR for this earlier. It should be going into this release.

cc @xtine 
