### PR TITLE
Position icons 1rem from right on certain buttons

### DIFF
--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -344,7 +344,7 @@
     background-position: u(1rem 50%);
     padding-left: $width + 2rem;
   } @else {
-    background-position: 90% 50%;
+    background-position: right u(1rem) top 50%;
     padding-right: $width + 2rem;
   }
 


### PR DESCRIPTION
For buttons with the icons on the right, rather than positioning those background images at `90%` from the left, this positions them at `1rem` from the right.

cc @porta-antiporta 