### PR TITLE
Temporarily hide filter count on calendar filters

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -512,4 +512,10 @@ function MultiFilter(elm) {
 MultiFilter.prototype = Object.create(Filter.prototype);
 MultiFilter.constructor = MultiFilter;
 
+// This is a temporary override for the calendar filters to not show filter count
+// Because this filter has multiple inputs with the same name,
+// the filter count gets updated for each one,
+// resulting in inflated numbers.
+MultiFilter.prototype.handleAddEvent = function() { return; };
+
 module.exports = {Filter: Filter};


### PR DESCRIPTION
## Summary
This is a temporary fix to prevent a bug from shipping out, but we'll want to actually fix this eventually. Here's the problem: the calendar filters each have the same `name` attribute: `category`. So the check that we have on the `handleAddEvent` method to see see if the event name === the filter name passes for all of them on every `filter:added` event. 

The reason they all share the same `name` is that we really just have one API filter for `category` but on the frontend we break it out by different subgroups. That's what the `MultiFilter` class is designed to handle.

So this solution just adds an empty `handleAddEvent` method to the `MultiFilter` class to prevent any count from being added.

## Screenshots
Current:
![image](https://cloud.githubusercontent.com/assets/1696495/17375637/ab1232c2-5966-11e6-8359-32f5578bdbfc.png)

cc @xtine 
