### PR TITLE
Line chart styles & modals

### DIFF
--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -19,13 +19,13 @@
           </div>
         </form>
       </div>
-      <div class="mega__column is-disabled">
+      <div class="mega__column">
         <div class="mega-heading">
           <h3 class="mega-heading__title icon-heading--overviews">Interactive overviews</h3>
         </div>
         <ul>
-          <li class="mega__item is-disabled">Fundraising</li>
-          <li class="mega__item is-disabled">Spending</li>
+          <li class="mega__item"><a href="{{webAPpUrl}}#raising">Raising</a></li>
+          <li class="mega__item"><a href="{{webAPpUrl}}#spending">Spending</a></li>
         </ul>
       </div>
       <div class="mega__column">

--- a/js/templates/nav-data.hbs
+++ b/js/templates/nav-data.hbs
@@ -24,8 +24,8 @@
           <h3 class="mega-heading__title icon-heading--overviews">Interactive overviews</h3>
         </div>
         <ul>
-          <li class="mega__item"><a href="{{webAPpUrl}}#raising">Raising</a></li>
-          <li class="mega__item"><a href="{{webAPpUrl}}#spending">Spending</a></li>
+          <li class="mega__item"><a href="{{webAppUrl}}#raising">Raising</a></li>
+          <li class="mega__item"><a href="{{webAppUrl}}#spending">Spending</a></li>
         </ul>
       </div>
       <div class="mega__column">

--- a/scss/components/_charts.scss
+++ b/scss/components/_charts.scss
@@ -386,10 +386,34 @@ $tooltip-border-color: #999;
   stroke: $primary;
 }
 
-// Snapshot
+// Snapshot component
+// Accompanies a line chart to show the totals at a given point
+.snapshot {
+  border-bottom: 2px solid $primary;
+
+  @include media($med) {
+    @include span-columns(4);
+  }
+
+  @include media($lg) {
+    @include span-columns(3);
+  }
+}
+
+.snapshot__item-title {
+  font-weight: bold;
+}
+
+.snapshot__item {
+  font-family: $sans-serif;
+  font-size: u(1.4rem);
+  padding: u(.5rem 0);
+  border-bottom: 1px solid $gray-light;
+}
+
 .snapshot__controls {
   @include clearfix();
-  border-width: 2px 0 2px 0;
+  border-width: 2px 0;
   border-style: solid;
   border-color: $primary;
   padding: 2px 0;
@@ -413,5 +437,4 @@ $tooltip-border-color: #999;
     float: right;
     padding: u(1.5rem 1rem);
   }
-
 }

--- a/scss/components/_charts.scss
+++ b/scss/components/_charts.scss
@@ -351,3 +351,67 @@ $tooltip-border-color: #999;
     stroke-style: dashed;
   }
 }
+
+// Line charts
+.line--candidates {
+  stroke: $deep-aqua;
+
+  circle {
+    fill: $deep-aqua;
+  }
+}
+
+.line--pacs {
+  stroke: $gray;
+
+  circle {
+    fill: $gray;
+  }
+}
+
+.line--party {
+  stroke: $aqua;
+
+  circle {
+    fill: $aqua;
+  }
+}
+
+.cursor {
+  stroke: $gray;
+}
+
+// Bottom x axis
+.y .tick:first-child line {
+  stroke: $primary;
+}
+
+// Snapshot
+.snapshot__controls {
+  @include clearfix();
+  border-width: 2px 0 2px 0;
+  border-style: solid;
+  border-color: $primary;
+  padding: 2px 0;
+  text-align: center;
+
+  h5 {
+    display: inline-block;
+    font-family: $sans-serif;
+    font-size: u(1.4rem);
+    font-weight: bold;
+    padding: u(.8rem 0);
+    margin: 0;
+  }
+
+  .button--previous {
+    float: left;
+    padding: u(1.5rem 1rem);
+  }
+
+  .button--next {
+    float: right;
+    padding: u(1.5rem 1rem);
+  }
+
+}

--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -24,6 +24,7 @@
 @import 'maps'; //@TODO: Address later
 @import 'mega-menu'; // DOCUMENT
 @import 'messages';
+@import 'modals';
 @import 'options';
 @import 'overlay';
 @import 'overviews';

--- a/scss/components/_modals.scss
+++ b/scss/components/_modals.scss
@@ -22,12 +22,15 @@
   z-index: $z-max;
 
   @include media($med) {
-    @include transform(translate(-50%, -50%));
-    bottom: auto;
     left: 50%;
     right: auto;
-    top: 50%;
-    max-width: u(800rem);
+    margin-left: u(-30rem);
+    width: u(60rem);
+  }
+
+  @include media($lg) {
+    margin-left: u(-40rem);
+    width: u(80rem);
   }
 }
 

--- a/scss/components/_modals.scss
+++ b/scss/components/_modals.scss
@@ -1,0 +1,38 @@
+// Modal
+
+.modal-overlay {
+  background-color: rgba($base, .5);
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  position: fixed;
+  z-index: $z-max;
+}
+
+.modal__content {
+  background-color: $inverse;
+  bottom: u(2rem);
+  left: u(2rem);
+  right: u(2rem);
+  top: u(2rem);
+  overflow-y: scroll;
+  padding: u(2rem);
+  position: fixed;
+  z-index: $z-max;
+
+  @include media($med) {
+    @include transform(translate(-50%, -50%));
+    bottom: auto;
+    left: 50%;
+    right: auto;
+    top: 50%;
+    max-width: u(800rem);
+  }
+}
+
+.modal__close {
+  position: absolute;
+  right: u(1rem);
+  top: u(1rem);
+}

--- a/scss/components/_modals.scss
+++ b/scss/components/_modals.scss
@@ -1,6 +1,6 @@
 // Modal
 
-.modal-overlay {
+.modal__overlay {
   background-color: rgba($base, .5);
   bottom: 0;
   left: 0;

--- a/scss/components/_overviews.scss
+++ b/scss/components/_overviews.scss
@@ -5,8 +5,9 @@
 
 .overview__total {
   font-family: $sans-serif;
-  font-size: u(1.6rem);
-  margin-bottom: u(1rem);
+  font-size: u(1.4rem);
+  padding: u(.5rem 0);
+  border-bottom: 1px solid $gray-light;
 }
 
 .overview__total-title {
@@ -55,7 +56,6 @@
 @include media($med) {
   .overview__totals {
     @include span-columns(4);
-    padding-right: u(2rem);
   }
 
   .overview__chart {
@@ -72,16 +72,10 @@
 @include media($lg) {
   .overview__totals {
     @include span-columns(3);
-    padding-right: u(2rem);
   }
 
   .overview__chart {
-    @include span-columns(6);
-  }
-
-  .overview__feedback {
-    @include span-columns(3);
-    clear: none;
+    @include span-columns(9);
   }
 
   .top-list {

--- a/scss/components/_overviews.scss
+++ b/scss/components/_overviews.scss
@@ -3,17 +3,6 @@
   padding: u(2rem) 0;
 }
 
-.overview__total {
-  font-family: $sans-serif;
-  font-size: u(1.4rem);
-  padding: u(.5rem 0);
-  border-bottom: 1px solid $gray-light;
-}
-
-.overview__total-title {
-  font-weight: bold;
-}
-
 .overview__chart {
   position: relative;
 
@@ -54,10 +43,6 @@
 }
 
 @include media($med) {
-  .overview__totals {
-    @include span-columns(4);
-  }
-
   .overview__chart {
     @include span-columns(8);
     @include omega();
@@ -70,10 +55,6 @@
 }
 
 @include media($lg) {
-  .overview__totals {
-    @include span-columns(3);
-  }
-
   .overview__chart {
     @include span-columns(9);
   }

--- a/scss/elements/_elements.scss
+++ b/scss/elements/_elements.scss
@@ -37,6 +37,12 @@ body {
   position: relative;
 }
 
+main {
+  &[aria-hidden="true"] {
+    display: block !important;
+  }
+}
+
 [aria-hidden=true] {
   display: none !important;
 }


### PR DESCRIPTION
It's ugly, but this includes some new styles to support the [new chart work](https://github.com/18F/openFEC-web-app/pull/1508). 

- Activates nav links to "raising" and "spending" overviews, that are set to anchor links on /data
- Adds styles for line chart:
![image](https://cloud.githubusercontent.com/assets/1696495/17613081/63bf1076-600e-11e6-9c54-660c9152bc5b.png)
- Refactors `.overview__totals` as `.snapshot`, which accompanies the chart:
![image](https://cloud.githubusercontent.com/assets/1696495/17613100/812a1a98-600e-11e6-996c-de29cdadea5c.png)
- Adds styles for modals:
![image](https://cloud.githubusercontent.com/assets/1696495/17613104/9560e064-600e-11e6-9018-6bbc654cd06b.png)
- Note: modals require setting `main[aria-hidden="true"] { display: block }` because the modal library sets `aria-hidden="true"` on the `main` element when the modal is open, but we want it to still be visible behind the modal