### PR TITLE
Making sidebar text color always white

### DIFF
--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -52,7 +52,7 @@
   margin: 0;
   padding: u(1rem 2rem);
   text-transform: uppercase;
-  @include u-font-color($inverse);
+  font-color: $inverse;
 }
 
 .sidebar__content {
@@ -99,5 +99,6 @@
 
 .sidebar--neutral {
   @include u-bg--neutral();
+  @include u-font-color($base);
   border-top: 4px solid $primary;
 }

--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -52,6 +52,7 @@
   margin: 0;
   padding: u(1rem 2rem);
   text-transform: uppercase;
+  @include u-font-color($inverse);
 }
 
 .sidebar__content {
@@ -74,7 +75,6 @@
 .sidebar--primary {
   .sidebar__title {
     @include u-bg--primary();
-    @include u-font-color($primary-contrast);
   }
 
   .sidebar__section {
@@ -85,7 +85,6 @@
 .sidebar--secondary {
   .sidebar__title {
     @include u-bg--secondary();
-    @include u-font-color($secondary-contrast);
   }
 
   .sidebar__section {

--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -52,7 +52,7 @@
   margin: 0;
   padding: u(1rem 2rem);
   text-transform: uppercase;
-  font-color: $inverse;
+  color: $inverse;
 }
 
 .sidebar__content {


### PR DESCRIPTION
## Summary

Sets the sidebar title text color to `.inverse` so that it's white text over the primary or secondary background color at all times. This makes it just a bit easier on the eyes and more consistent across the site.

## Screenshots

**Before**
<img width="269" alt="screen shot 2016-08-11 at 9 58 08 am" src="https://cloud.githubusercontent.com/assets/11636908/17591582/cd6adb48-5fac-11e6-99fb-e1e09a880e40.png">

**After**
![screen shot 2016-08-11 at 10 16 57 am](https://cloud.githubusercontent.com/assets/11636908/17591583/cd6ea41c-5fac-11e6-8b96-80ac3fc68df7.png)



cc @adborden for https://github.com/18F/openFEC-web-app/pull/1505

