### PR TITLE
Refine filter interactions

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -420,6 +420,8 @@ TypeaheadFilter.prototype.handleNestedChange = function(e) {
     {
       key: id,
       value: $label.text(),
+      name: $input.attr('name'),
+      loadedOnce: true
     }
   ]);
 };

--- a/js/filters.js
+++ b/js/filters.js
@@ -148,6 +148,9 @@ Filter.prototype.handleChange = function(e) {
     value = $input.val();
     loadedOnce = $input.data('loaded-once') || false;
 
+    // set focus to button
+    $input.next().focus();
+
     if ($input.data('had-value') && value.length > 0) {
       eventName = 'filter:renamed';
     } else if (value.length > 0) {

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -91,9 +91,7 @@ TypeaheadFilter.prototype.handleSelect = function(e, datum) {
   });
   this.datum = null;
 
-  this.$button.focus();
-
-  this.$button.addClass('is-loading');
+  this.$button.focus().addClass('is-loading');
 };
 
 TypeaheadFilter.prototype.handleAutocomplete = function(e, datum) {

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -51,7 +51,6 @@ var TypeaheadFilter = function(selector, dataset, allowText) {
   this.$field.on('typeahead:selected', this.handleSelect.bind(this));
   this.$field.on('typeahead:autocomplete', this.handleAutocomplete.bind(this));
   this.$field.on('typeahead:render', this.setFirstItem.bind(this));
-  this.$field.on('blur', this.handleBlur.bind(this));
   this.$field.on('keyup', this.handleKeypress.bind(this));
   this.$button.on('click', this.handleSubmit.bind(this));
 
@@ -92,6 +91,8 @@ TypeaheadFilter.prototype.handleSelect = function(e, datum) {
   });
   this.datum = null;
 
+  this.$button.focus();
+
   this.$button.addClass('is-loading');
 };
 
@@ -104,13 +105,6 @@ TypeaheadFilter.prototype.handleKeypress = function(e) {
 
   if (e.keyCode === 13) {
     this.handleSubmit(e);
-  }
-};
-
-TypeaheadFilter.prototype.handleBlur = function() {
-  // If the user starts typing but then leaves the field clear the input
-  if (!this.datum && !this.allowText) {
-    this.clearInput();
   }
 };
 

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -44,7 +44,10 @@ var TypeaheadFilter = function(selector, dataset, allowText) {
   this.$button = this.$body.find('button');
   this.$selected = this.$body.find('.dropdown__selected');
 
-  this.$body.on('change', 'input', this.handleChange.bind(this));
+  this.$body.on('change', 'input[type="text"]', this.handleChange.bind(this));
+  this.$body.on('change', 'input[type="checkbox"]', this.handleCheckbox.bind(this));
+  this.$body.on('click', '.dropdown__remove', this.removeCheckbox.bind(this));
+
   this.$body.on('mouseenter', '.tt-suggestion', this.handleHover.bind(this));
   $('body').on('filter:modify', this.changeDataset.bind(this));
 
@@ -83,13 +86,17 @@ TypeaheadFilter.prototype.setFirstItem = function() {
 };
 
 TypeaheadFilter.prototype.handleSelect = function(e, datum) {
+  var id = this.fieldName + '-' + slugify(datum.id) + '-checkbox';
+
   this.appendCheckbox({
     name: this.fieldName,
     label: formatLabel(datum),
     value: datum.id,
-    id: this.fieldName + '-' + slugify(datum.id) + '-checkbox'
+    id: id
   });
   this.datum = null;
+
+  this.$body.find('label[for="' + id + '"]').addClass('is-loading');
 
   this.$button.focus().addClass('is-loading');
 };
@@ -114,6 +121,25 @@ TypeaheadFilter.prototype.handleChange = function() {
     this.datum = null;
     this.disableButton();
   }
+};
+
+TypeaheadFilter.prototype.handleCheckbox = function(e) {
+  var $input = $(e.target);
+  var id = $input.attr('id');
+  var $label = this.$body.find('label[for="' + id + '"]');
+  var loadedOnce = $input.data('loaded-once') || false;
+
+  if (loadedOnce) {
+    $label.addClass('is-loading');
+  }
+
+  $input.data('loaded-once', true);
+};
+
+TypeaheadFilter.prototype.removeCheckbox = function(e) {
+  var $input = $(e.target);
+
+  $input.closest('li').remove();
 };
 
 TypeaheadFilter.prototype.handleHover = function() {
@@ -154,7 +180,10 @@ TypeaheadFilter.prototype.checkboxTemplate = _.template(
       'type="checkbox" ' +
       'checked' +
     '/>' +
-    '<label for="{{id}}">{{label}}</li>' +
+    '<label for="{{id}}">{{label}}</label>' +
+    '<button class="dropdown__remove">' +
+      '<span class="u-visually-hidden">Remove</span>' +
+    '</button>' +
   '</li>',
   {interpolate: /\{\{(.+?)\}\}/g}
 );

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -168,8 +168,12 @@
     position: relative;
 
     &:hover {
-      input[type="checkbox"]:not(:checked) + label:not(.is-loading) + button {
+      input[type="checkbox"]:not(:checked) + label:not(.is-loading) + .dropdown__remove {
         display: inline-block;
+      }
+
+      input[type="checkbox"]:not(:checked) + label.is-unsuccessful + .dropdown__remove {
+        display: none;
       }
     }
   }
@@ -184,7 +188,7 @@
 
   .dropdown__remove {
     @include u-icon-button($x, $gray-dark);
-    background-position: .75rem 50%;
+    background-position: u(.75rem) 50%;
     background-size: 18px;
     display: none;
     top: 0;

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -163,7 +163,7 @@
 .dropdown__selected {
   margin-bottom: u(.5rem);
 
-  .dropdown__item {
+  li {
     @include animation(fadeIn .2s ease-in);
     position: relative;
 

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -33,6 +33,10 @@
     top: u(.5rem);
   }
 
+  &.is-active::after {
+    @include u-icon-bg($arrow-up, $primary);
+  }
+
   &.is-loading {
     &::after {
       background-image: url('../img/loading-ellipsis-gray.gif');

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -117,7 +117,7 @@
       }
 
       &.is-checked {
-        @include u-icon-bg($check, $green-light);
+        @include u-icon-bg($check, $gray);
         background-color: $gray-light;
         background-position: right u(.5rem) top 50%;
         padding-right: u(1.5rem);

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -219,10 +219,6 @@ $search-button-width: u(5.6rem);
     padding: 0;
   }
 
-  .is-loading {
-    background-image: url('../img/loading-ellipsis-gray.gif');
-  }
-
   &[data-allow-text] {
     .tt-suggestion__missing {
       display: none;
@@ -235,11 +231,11 @@ $search-button-width: u(5.6rem);
       padding: 0;
     }
 
-    .is-loading {
+    button.is-loading {
       background-image: url('../img/loading-ellipsis-gray.gif');
     }
 
-    .is-successful {
+    button.is-successful {
       @include u-icon-button($check);
       background-size: u(2.8rem);
       background-position: 50%;

--- a/tests/typeahead-filter.js
+++ b/tests/typeahead-filter.js
@@ -81,15 +81,6 @@ describe('typeaheadFilter', function() {
     this.typeaheadFilter.handleSubmit.restore();
   });
 
-  it('should clear the input on blur if it does not allow free text', function() {
-    this.typeaheadFilter.datum = null;
-    this.typeaheadFilter.allowText = false;
-    this.typeaheadFilter.$field.focus();
-    this.typeaheadFilter.$field.typeahead('val','text');
-    this.typeaheadFilter.$field.blur();
-    expect(this.typeaheadFilter.$field.typeahead('val')).to.equal('');
-  });
-
   it('should enable and disable button when the input changes', function() {
     var enableButton = sinon.spy(this.typeaheadFilter, 'enableButton');
     var disableButton = sinon.spy(this.typeaheadFilter, 'disableButton');


### PR DESCRIPTION
## Summary
#### Filter error states
- Error states now removed upon success state
- Error "x" and checkbox removal "x" will not appear at the same time

#### Dropdowns
- Dropdown button will change to arrow icon pointing up on open state
- Selected dropdown item has gray checkmark instead of green

<img width="283" alt="screen shot 2016-08-11 at 12 07 42 pm" src="https://cloud.githubusercontent.com/assets/24054/17601307/4a3be612-5fbc-11e6-9608-1b008930f041.png">

#### Text input
- Text input submissions by enter keypress will change focus to button to address input blur issue

#### Typeahead
- Remove clear input upon blur functionality to resolve blur issues
- Ability to remove typeahead generated checkboxes (when unchecked)
- Show loading/success/remove states on typeahead generated checkboxes
- Show message of last added checkbox after checkbox instead of after typeahead input
- Typeahead add/removal of checkboxes increments and decrements filter panel and accordion counts appropriately

![ivjbe477o0](https://cloud.githubusercontent.com/assets/24054/17601434/00370c3a-5fbd-11e6-8046-e0b2c00393ee.gif)


#### Unique Only Tooltip
- Moved tooltip triggering icon within the label

<img width="191" alt="screen shot 2016-08-11 at 12 08 01 pm" src="https://cloud.githubusercontent.com/assets/24054/17601343/7d89374a-5fbc-11e6-8f58-adf060c91b24.png">

Addresses issue: 18F/openfec-web-app#1397
Relies on PR: 18F/openfec-web-app#1509

cc @noahmanger 