### PR TITLE
Calendar panel tweaks

### DIFF
--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -37,7 +37,7 @@ function FilterPanel(options) {
 }
 
 FilterPanel.prototype.setInitialDisplay = function() {
-  if (helpers.getWindowWidth() >= helpers.BREAKPOINTS.LARGE) {
+  if (helpers.isLargeScreen()) {
     this.show();
   } else if (!this.isOpen) {
     this.hide();
@@ -45,6 +45,10 @@ FilterPanel.prototype.setInitialDisplay = function() {
 };
 
 FilterPanel.prototype.show = function(focus) {
+  if (!helpers.isLargeScreen()) {
+    var top = this.$toggle.outerHeight() +  this.$toggle.position().top;
+    this.$content.css('top', top);
+  }
   this.$body.addClass('is-open');
   this.$content.attr('aria-hidden', false);
   accessibility.restoreTabindex(this.$form);

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -37,7 +37,7 @@ function FilterPanel(options) {
 }
 
 FilterPanel.prototype.setInitialDisplay = function() {
-  if (helpers.isLargeScreen()) {
+  if (helpers.getWindowWidth() >= helpers.BREAKPOINTS.LARGE) {
     this.show();
   } else if (!this.isOpen) {
     this.hide();

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -86,7 +86,8 @@ TagList.prototype.removeTag = function(key, emit) {
   }
 
   if (this.$list.find('.tag').length === 0) {
-    this.$resultType.html(this.opts.resultType);
+    var text = this.opts.emptyText ? this.opts.emptyText : this.opts.resultType;
+    this.$resultType.html(text);
     this.$list.attr('aria-hidden', true);
   }
 };

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -25,6 +25,11 @@
 // Controls
 .fc-toolbar {
   @include clearfix();
+  padding: u(1rem);
+}
+
+.calendar__head {
+  @include clearfix();
   border-bottom: 1px solid $neutral;
   padding: u(1rem);
 
@@ -532,7 +537,7 @@
 // - View buttons on the right
 
 @include media($med) {
-  .fc-toolbar {
+  .calendar__head {
     padding: u(1rem 2rem);
   }
 

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -114,7 +114,6 @@ $filter-button-width: u(4.6rem);
   position: absolute;
   bottom: 0;
   height: auto;
-  top: u(10.8rem);
   z-index: $z4;
   width: 100%;
   overflow: visible;


### PR DESCRIPTION
A few small changes to support https://github.com/18F/fec-cms/pull/424
- On small screens, set the `top` position of the filter panel with JS based on the position and size of the toggle button, rather than with CSS. This allows for variable content above the filter panel, as happens with the calendar.
- Adding a `emptyText` option to be passed to `FilterTags` so that the calendar can say `Viewing all events` when no tags are applied
- Minor CSS changes to adjust to new ways the calendar JS manipulates the DOM