### PR TITLE
Updated styles for advisory opinion pages

### DIFF
--- a/scss/components/_type-styles.scss
+++ b/scss/components/_type-styles.scss
@@ -154,7 +154,7 @@
 }
 
 .t-upper {
-  text-transform: uppercase;
+  @include t-upper;
 }
 
 .t-data-header {

--- a/scss/components/_type-styles.scss
+++ b/scss/components/_type-styles.scss
@@ -154,7 +154,7 @@
 }
 
 .t-upper {
-  @include t-upper;
+  text-transform: uppercase;
 }
 
 .t-data-header {

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -80,7 +80,3 @@
   font-weight: bold;
   padding: 0 0.3em;
 }
-
-@mixin t-upper {
-  text-transform: uppercase;
-}

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -13,7 +13,7 @@
     padding: u(1.2rem 0);
 
     @include media($med) {
-      font-size: u(4.8rem);
+      font-size: u(4rem);
     }
   }
 
@@ -79,4 +79,8 @@
   background: $gray-light;
   font-weight: bold;
   padding: 0 0.3em;
+}
+
+@mixin t-upper {
+  text-transform: uppercase;
 }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -19,19 +19,19 @@
 //       <td>1</td>
 //       <td>Red</td>
 //       <td>0.1234</td>
-//       <td>Minim in magna ex incididunt sit laborum exercitation aute do ullamco consectetur esse.</td>
+//       <td>Minim in magna ex incididunt sit laborum exercitation aute</td>
 //     </tr>
 //     <tr>
 //       <td>2</td>
 //       <td>Blue</td>
 //       <td>0.1234</td>
-//       <td>in dolore amet irure dolore commodo est aliquip labore sunt</td>
+//       <td>in dolore amet irure dolore commodo est aliquip</td>
 //     </tr>
 //     <tr>
 //       <td>3</td>
 //       <td>Green</td>
 //       <td>0.1234</td>
-//       <td>nostrud laborum in ullamco cillum laborum anim esse commodo aliqua</td>
+//       <td>nostrud laborum in ullamco cillum laborum</td>
 //     </tr>
 //   </tbody>
 // </table>
@@ -42,6 +42,7 @@
 //
 // .is-showing-filters    - Class applied to body when the filters are open, causing the datatable to shrink slightly
 // .data-table--text      - Textual tables for text-heavy search results.
+// .data-table--heading-borders      - Include cell borders in the header row when your table follows `.results-info`.
 //
 // Styleguide modules.datatables
 
@@ -71,7 +72,6 @@
     letter-spacing: -.3px;
     padding: u(.5rem 1rem);
     border-bottom: 1px solid $primary;
-    border-left: 1px solid $neutral;
 
     &.sorting,
     &.sorting_asc,
@@ -168,6 +168,12 @@
   // Special styles for tables that use `offsetX: true`
   &.scrollX {
     table-layout: auto;
+  }
+}
+
+.data-table--heading-borders {
+  th {
+    border-left: 1px solid $neutral;
   }
 }
 

--- a/scss/modules/_section-headings.scss
+++ b/scss/modules/_section-headings.scss
@@ -60,11 +60,11 @@
 }
 
 .heading__subtitle {
-  @include t-upper;
   font-family: $sans-serif;
   font-weight: bold;
   letter-spacing: -.3px;
   margin-bottom: u(1rem);
+  text-transform: uppercase;
 }
 
 .heading__action {

--- a/scss/modules/_section-headings.scss
+++ b/scss/modules/_section-headings.scss
@@ -1,18 +1,13 @@
 // Section headings
 //
-// Contain the title, date select and action button
+// Contain the title, date select and action button.
 //
 // Markup:
 // <div class="section__heading">
-//  <h2 class="heading__title">Heading title
-//     <select class="cycle-select">
-//       <option>Option 1</option>
-//     </select>
-//   </h2>
-//   <a class="heading__action button--alt button--browse">Browse</a>
+//  <h2 class="heading__title">Heading title</h2>
 // </div>
 //
-// Styleguide modules.section-headings
+// Styleguide modules.section-headings.0
 
 .section__heading {
   @include clearfix();
@@ -20,6 +15,22 @@
   margin-bottom: u(1rem);
 }
 
+// With action
+//
+// When the heading title includes an action.
+//
+// Markup:
+// <div class="section__heading">
+//  <h2 class="heading__title heading__title--with-action">A heading with an action</h2>
+//  <div class="heading__action">
+//    <ul class="list--buttons">
+//      <li><a class="button button--standard button--table" href="#">Explore data</a></li>
+//      <li><button class="button button--standard button--share">Share</button></li>
+//    </ul>
+//  </div>
+//
+// Styleguide modules.section-headings.1
+//
 .heading__title {
   border-bottom: 0;
   margin-bottom: u(1rem);
@@ -30,7 +41,29 @@
   }
 }
 
+// Heading main
+//
+// When the heading title is also the title of the page.
+//
+// Markup:
+// <div class="section__heading">
+//  <h1 class="heading__title heading__title--main">Page title</h1>
+//  <span class="heading__subtitle">A subtitle</span>
+// </div>
+//
+// Styleguide modules.section-headings.2
+
+.heading__title--main {
+  @include heading(display);
+  margin: 0;
+  padding: 0;
+}
+
 .heading__subtitle {
+  @include t-upper;
+  font-family: $sans-serif;
+  font-weight: bold;
+  letter-spacing: -.3px;
   margin-bottom: u(1rem);
 }
 
@@ -75,7 +108,7 @@
     }
   }
 
-  .heading__title {
+  .heading__title--with-action {
     float: left;
   }
 


### PR DESCRIPTION
## Summary

### Data table heading borders

Adds a subclass `.data-table--heading-borders` to get cell borders in the header row. Some tables aren't adjacent to heading or a `.results-info` and thus don't have a top border, so having borders in the header row is awkward.

![screenshot from 2016-08-11 18-11-36](https://cloud.githubusercontent.com/assets/509703/17610035/18617fac-5fef-11e6-9eb6-acfd59e8b8ae.png)

### Heading styles

Create a new component based on the heading styles with a subtitle. I also moved the float property from the default `heading__title` to a new subclass `heading__title--with-action`.

![screenshot from 2016-08-11 17-02-50](https://cloud.githubusercontent.com/assets/509703/17610055/41c6f1f6-5fef-11e6-97d3-6bdc452b4f5c.png)


_cc @noahmanger @jenniferthibault _
