### PR TITLE
Tooltip tweaks for Unique Receipts

### DIFF
--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -39,6 +39,7 @@
 .tooltip__content.tooltip__content { // Hack to override any font color styles on the parent element
   color: $primary;
   text-align: left;
+  text-transform: initial;
   font-size: u(1.4rem);
   font-weight: normal;
   line-height: 1.4;

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -287,7 +287,6 @@ $filter-button-width: u(4.6rem);
       top: 0;
       left: 0;
       width: u(30rem);
-      z-index: 0;
 
       .filters__header {
         width: 100%;


### PR DESCRIPTION
Further updates for 18F/openfec-web-app#1397:
- Fix z-index for unique receipts tooltip
- Prevent all caps tooltip content

<img width="372" alt="screen shot 2016-08-11 at 8 51 57 pm" src="https://cloud.githubusercontent.com/assets/24054/17612361/d50ed486-6005-11e6-9be8-840b43412bfc.png">

cc @noahmanger 