### PR TITLE
Renaming class to fix padding

### DIFF
--- a/scss/modules/_data-container.scss
+++ b/scss/modules/_data-container.scss
@@ -57,9 +57,7 @@
 }
 
 .data-container__body {
-  &.fade-in {
-    opacity: 0;
-  }
+  padding: u(0 1rem);
 }
 
 .data-container__tags {
@@ -106,7 +104,11 @@
 
   .data-container__body {
     border-top: 0;
-    padding-left: u(2rem);
+    padding: u(0 2rem);
+  }
+
+  .data-container__datatable {
+    padding: u(0 0 0 2rem);
   }
 
   .data-container__widgets {


### PR DESCRIPTION
Fixes padding confusion.

On data table pages:
![image](https://cloud.githubusercontent.com/assets/1696495/17638591/f9553a66-609f-11e6-9045-e3caf0c66e55.png)

On legal search pages:
![image](https://cloud.githubusercontent.com/assets/1696495/17638602/04da551a-60a0-11e6-859b-790e8d14b504.png)
