### PR TITLE
Add button for document icon

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -338,17 +338,17 @@
 // Icon color matches text color and small vertical line between icon and text. Uses the u-icon-button mixin.
 // Defaults to the styles for button--alt and button--standard, with overrides for other classes
 //
-// .button--go          - Go
-// .button--browse      - For links to the datatable view
-// .button--map         - Map button
-// .button--table       - Table button
+// .button--browse                  - For links to the datatable view
+// .button--document                - Document button
+// .button--download                - Download button
+// .button--list                    - List view button
+// .button--map                     - Map button
+// .button--search--text            - Search with text
+// .button--subscribe               - Subscribe button
 // .button--two-candidates          - Toggle two-candidate view on map comparison
 // .button--export                  - Export button
-// .button--download                - Download button
-// .button--subscribe               - Subscribe button
-// .button--cal                     - Calendar view button
-// .button--list                    - List view button
-// .button--search--text            - Search with text
+// .button--go                      - Go
+// .button--table                   - Table button
 //
 // Markup:
 // <button class="button--standard {{ modifier_class }}">Button</button>
@@ -386,6 +386,10 @@
 
 .button--export {
   @include u-icon-button($download, right);
+}
+
+.button--document {
+  @include u-icon-button($document, left);
 }
 
 .button--download {


### PR DESCRIPTION
Includes the document button from https://github.com/18F/fec-style/pull/462

![screenshot from 2016-08-12 20-48-51](https://cloud.githubusercontent.com/assets/509703/17641293/35ea1ad6-60ce-11e6-9f32-d15fc325e50c.png)

Fixes https://github.com/18F/fec-eregs/issues/212