### PR TITLE
New tag styles

### DIFF
--- a/js/dropdowns.js
+++ b/js/dropdowns.js
@@ -41,7 +41,6 @@ function Dropdown(selector, opts) {
     }
   }
 
-  $(document.body).on('tag:removed', this.handleRemoveClick.bind(this));
   $(document.body).on('tag:removeAll', this.handleClearFilters.bind(this));
 
   this.$button.on('click', this.toggle.bind(this));

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -60,7 +60,7 @@ FilterSet.prototype.handleTagRemove = function(e, opts) {
   var type = $input.get(0).type;
 
   if (type === 'checkbox' || type === 'radio') {
-    $input.attr('checked', false).trigger('change');
+    $input.click();
   } else if (type === 'text') {
     $input.val('').trigger('change');
   }

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -57,14 +57,14 @@ function TagList(opts) {
 
 TagList.prototype.addTag = function(e, opts) {
   var tag = opts.nonremovable ? NONREMOVABLE_TAG_TEMPLATE(opts) : TAG_TEMPLATE(opts);
-  var $tagGroup = this.$list.find('[data-tag-group="' + opts.name + '"]');
+  var $tagCategory = this.$list.find('[data-tag-category="' + opts.name + '"]');
   this.removeTag(opts.key, false);
 
-  if ($tagGroup.length > 0) {
-    $tagGroup.append(tag);
+  if ($tagCategory.length > 0) {
+    $tagCategory.append(tag);
   }
   else {
-    this.$list.append('<li data-tag-group="' + opts.name + '" class="tag__group">' + tag + '</li>');
+    this.$list.append('<li data-tag-category="' + opts.name + '" class="tag__category">' + tag + '</li>');
   }
 
   if (this.$list.find('.tag__item').length > 0) {
@@ -79,7 +79,7 @@ TagList.prototype.addTag = function(e, opts) {
 
 TagList.prototype.removeTag = function(key, emit) {
   var $tag = this.$list.find('[data-id="' + key + '"]');
-  var $tagGroup = $tag.parent();
+  var $tagCategory = $tag.parent();
 
   if ($tag.length > 0) {
     if (emit) {
@@ -88,8 +88,8 @@ TagList.prototype.removeTag = function(key, emit) {
 
     $tag.remove();
 
-    if ($tagGroup.is(':empty')) {
-      $tagGroup.remove();
+    if ($tagCategory.is(':empty')) {
+      $tagCategory.remove();
     }
   }
 
@@ -104,7 +104,7 @@ TagList.prototype.removeTag = function(key, emit) {
   }
 };
 
-TagList.prototype.removeAllTags = function(e) {
+TagList.prototype.removeAllTags = function() {
   var self = this;
 
   this.$list.find('[data-removable]').each(function(){

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -29,7 +29,7 @@ var TAG_TEMPLATE = _.template(
 );
 
 var NONREMOVABLE_TAG_TEMPLATE = _.template(
-  '<div data-id="{{ key }}" data-removable="true" class="tag__item">' +
+  '<div data-id="{{ key }}" data-removable="false" class="tag__item">' +
     '{{ value }}' +
   '</div>',  {interpolate: /\{\{(.+?)\}\}/g}
 );
@@ -83,7 +83,7 @@ TagList.prototype.removeTag = function(key, emit) {
   var $tag = this.$list.find('[data-id="' + key + '"]');
   var $tagCategory = $tag.parent();
 
-  if ($tag.length > 0) {
+  if ($tag.length > 0 && $tag.attr('data-removable') !== 'false') {
     if (emit) {
       $tag.trigger('tag:removed', [{key: key}]);
     }

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -22,9 +22,8 @@
   background-color: $gray-light;
   border-radius: 2px;
   display: inline-block;
-  // padding: u(.5rem .75rem);
   padding: u(0 .75rem .5rem .7rem);
-  margin: u(.5rem .5rem 0);
+  margin: u(.5rem .5rem 0 0);
 
   .tag__item {
     display: inline-block;
@@ -34,7 +33,7 @@
     color: $primary;
     font-family: $sans-serif;
     letter-spacing: -.3px;
-    padding: u(.5rem .75rem);
+    padding: u(0 .5rem 0 .75rem);
     margin: u(.5rem 3rem 0 0);
     position: relative;
 

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -15,20 +15,44 @@
 }
 
 .tags {
-  padding: 5px 0;
   width: 100%;
 }
 
-.tag {
+.tag__group {
+  background-color: $gray-light;
+  border-radius: 2px;
   display: inline-block;
-  background-color: $inverse;
-  border: 1px solid $gray;
-  border-radius: 4px;
-  color: $primary;
-  font-family: $sans-serif;
-  letter-spacing: -.3px;
-  margin: 0 4px 2px 0;
-  padding: u(2px .75rem);
+  // padding: u(.5rem .75rem);
+  padding: u(0 .75rem .5rem .7rem);
+  margin: u(.5rem .5rem 0);
+
+  .tag__item {
+    display: inline-block;
+    background-color: $inverse;
+    border: 1px solid $gray;
+    border-radius: 4px;
+    color: $primary;
+    font-family: $sans-serif;
+    letter-spacing: -.3px;
+    padding: u(.5rem .75rem);
+    margin: u(.5rem 3rem 0 0);
+    position: relative;
+
+    &::after {
+      content: 'or';
+      font-weight: bold;
+      position: absolute;
+      right: u(-2.25rem);
+    }
+
+    &:last-child {
+      margin-right: 0;
+
+      &::after {
+        content: '';
+      }
+    }
+  }
 }
 
 .tag__remove {

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -18,7 +18,7 @@
   width: 100%;
 }
 
-.tag__group {
+.tag__category {
   background-color: $gray-light;
   border-radius: 2px;
   display: inline-block;

--- a/tests/filter-tags.js
+++ b/tests/filter-tags.js
@@ -34,28 +34,29 @@ describe('filter tags', function() {
   describe('addTag()', function() {
     it('adds tag on invoke', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.length).to.equal(1);
       expect(tag.text()).to.contain('timmy');
     });
 
     it('removes existing tags by key', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
-      this.tagList.addTag({}, {key: 'name', value: 'kyle'});
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      this.tagList.removeTag({}, {key: 'name', value: 'kyle'});
+      var tag = this.tagList.$list.find('[data-id="name"]');
+
       expect(tag.length).to.equal(1);
-      expect(tag.text()).to.contain('kyle');
+      expect(tag.text()).to.contain('timmy');
     });
 
     it('adds tag on event', function() {
       $(document.body).trigger('filter:added', [{key: 'name', value: 'timmy'}]);
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.length).to.equal(1);
     });
 
     it('it does not add remove button if nonremovable is true', function(){
       $(document.body).trigger('filter:added', [{key: 'name', value: 'timmy', nonremovable: true}]);
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.find('button')).to.have.length(0);
     });
   });
@@ -72,16 +73,16 @@ describe('filter tags', function() {
     it('removes tag on invoke', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
       this.tagList.removeTag('name', true);
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.length).to.equal(0);
       expect($.prototype.trigger).to.have.been.calledWith('tag:removed', [{key: 'name'}]);
     });
 
     it('removes tag on dom event', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       tag.find('.js-close').trigger('click');
-      tag = this.tagList.$list.find('li[data-id="name"]');
+      tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.length).to.equal(0);
     });
   });
@@ -90,14 +91,14 @@ describe('filter tags', function() {
     it('renames tag on invoke', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
       this.tagList.renameTag({}, {key: 'name', value: 'butters'});
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.text()).to.contain('butters');
     });
 
     it('renames tag on event', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
       $(document.body).trigger('filter:renamed', [{key: 'name', value: 'butters'}]);
-      var tag = this.tagList.$list.find('li[data-id="name"]');
+      var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.text()).to.contain('butters');
     });
   });

--- a/tests/filter-tags.js
+++ b/tests/filter-tags.js
@@ -101,6 +101,20 @@ describe('filter tags', function() {
       tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.length).to.equal(0);
     });
+
+    it('clear all removes all removable tags', function() {
+      this.tagList.addTag({}, {key: 'name', value: 'hillary'});
+      this.tagList.removeAllTags();
+      var tags = this.tagList.$list.find('li');
+      expect(tags.length).to.equal(0);
+    });
+
+    it('clear all does not remove a nonremovable tag', function() {
+      this.tagList.addTag({}, {key: 'name', value: 'aaron', nonremovable: true});
+      this.tagList.removeAllTags();
+      var tags = this.tagList.$list.find('li');
+      expect(tags.length).to.equal(1);
+    });
   });
 
   describe('renameTag()', function() {

--- a/tests/filter-tags.js
+++ b/tests/filter-tags.js
@@ -39,6 +39,14 @@ describe('filter tags', function() {
       expect(tag.text()).to.contain('timmy');
     });
 
+    it('adds tag in correct category', function () {
+      this.tagList.addTag({}, {key: 'name', name: 'people', value: 'xtine'});
+      this.tagList.addTag({}, {key: 'checkbox', name: 'secretary', value: 'john'});
+      var tagCategory = this.tagList.$list.find('[data-tag-category="people"]');
+      expect(tagCategory.length).to.equal(1);
+      expect(tagCategory.text()).to.contain('xtine');
+    });
+
     it('removes existing tags by key', function() {
       this.tagList.addTag({}, {key: 'name', value: 'timmy'});
       this.tagList.removeTag({}, {key: 'name', value: 'kyle'});
@@ -59,6 +67,7 @@ describe('filter tags', function() {
       var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.find('button')).to.have.length(0);
     });
+
   });
 
   describe('removeTag()', function() {
@@ -76,6 +85,13 @@ describe('filter tags', function() {
       var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.length).to.equal(0);
       expect($.prototype.trigger).to.have.been.calledWith('tag:removed', [{key: 'name'}]);
+    });
+
+    it('removes tag category', function() {
+      this.tagList.addTag({}, {key: 'name', name: 'people', value: 'xtine'});
+      this.tagList.removeTag('name', true);
+      var tagCategory = this.tagList.$list.find('[data-tag-category="people"]');
+      expect(tagCategory.length).to.equal(0);
     });
 
     it('removes tag on dom event', function() {


### PR DESCRIPTION
New design and functionality of tags:
- Tags are now shown in category blocks and separated by "or" text between them.

<img width="940" alt="screen shot 2016-08-16 at 12 35 38 pm" src="https://cloud.githubusercontent.com/assets/24054/17713325/260e26aa-63af-11e6-94cf-bff05841cec3.png">

--

<img width="941" alt="screen shot 2016-08-16 at 12 35 59 pm" src="https://cloud.githubusercontent.com/assets/24054/17713326/26117ae4-63af-11e6-9a0b-739252c0a22c.png">

--

<img width="945" alt="screen shot 2016-08-16 at 12 37 50 pm" src="https://cloud.githubusercontent.com/assets/24054/17713324/260e0404-63af-11e6-85a9-abb791539ec9.png">

--

<img width="330" alt="screen shot 2016-08-16 at 12 35 19 pm" src="https://cloud.githubusercontent.com/assets/24054/17713329/29580254-63af-11e6-86f8-25c87c8c1c56.png">

18F/openFEC-web-app#1380