### PR TITLE
Tooltip alignment fix

### DIFF
--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -43,7 +43,6 @@
   font-size: u(1.4rem);
   font-weight: normal;
   line-height: 1.4;
-  margin-bottom: 0;
 
   a {
     border-bottom-color: $primary;
@@ -52,6 +51,10 @@
 
   li {
     font-size: u(1.4rem);
+  }
+
+  &:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -98,8 +98,11 @@
   }
 
   &.tooltip--left {
-    left: auto;
-    right: u(-14rem);
+    left: u(-2rem);
+
+    &::before {
+      left: u(2.8rem);
+    }
   }
 }
 


### PR DESCRIPTION
This fixes the alignment of the `.tooltip--left` class so the tip is just off the left side of the box. Otherwise, the box is positioned in such a way that if it's close to the left side of the screen, it will be cut off.

![image](https://cloud.githubusercontent.com/assets/1696495/17719898/afdafc14-63d2-11e6-9ecb-a1ac20ded14d.png)

![image](https://cloud.githubusercontent.com/assets/1696495/17719905/bb3599c0-63d2-11e6-91bb-89f28a6dc77f.png)
