### PR TITLE
Filter and analytics

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -15,7 +15,7 @@ function trackerExists() {
  * This tracker's name is "nonDAP", so all commands will need to be prefixed
 */
 function init() {
-  if (!trackerExists) {
+  if (!trackerExists()) {
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/js/filters.js
+++ b/js/filters.js
@@ -244,7 +244,7 @@ Filter.prototype.disable = function() {
     if ($this.is(':checked')) {
       $this.trigger('filter:disabled', {
         key: $this.attr('id')
-      });            
+      });
     }
   });
   this.isEnabled = false;
@@ -256,7 +256,7 @@ Filter.prototype.enable = function() {
     $this.removeClass('is-disabled').prop('disabled', false);
     $this.trigger('filter:enabled', {
         key: $this.attr('id')
-      });      
+      });
   });
   this.isEnabled = true;
 }
@@ -459,17 +459,17 @@ TypeaheadFilter.prototype.disable = function() {
   this.$body.find('input:checked').each(function() {
     $(this).trigger('filter:disabled', {
       key: $(this).attr('id')
-    });            
-  });  
+    });
+  });
 };
 
 TypeaheadFilter.prototype.enable = function() {
-  this.$body.find('input, button').removeClass('is-disabled').prop('disabled', false);
+  this.$body.find('input, label, button').removeClass('is-disabled').prop('disabled', false);
   this.$body.find('input:checked').each(function() {
     $(this).trigger('filter:enabled', {
       key: $(this).attr('id')
-    });            
-  });    
+    });
+  });
 };
 
 function ElectionFilter(elm) {
@@ -589,7 +589,7 @@ ToggleFilter.prototype.fromQuery = function(query) {
 ToggleFilter.prototype.handleChange = function(e) {
   var value = $(e.target).val();
   var id = this.$input.attr('id');
-  var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';  
+  var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';
   this.$body.trigger(eventName, [
     {
       key: id,
@@ -598,9 +598,9 @@ ToggleFilter.prototype.handleChange = function(e) {
       name: this.name,
       nonremovable: true
     }
-  ]);  
-  
-  this.loadedOnce = true;  
+  ]);
+
+  this.loadedOnce = true;
 }
 
 module.exports = {Filter: Filter};

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -43,7 +43,6 @@
   font-size: u(1.4rem);
   font-weight: normal;
   line-height: 1.4;
-  margin-bottom: 0;
 
   a {
     border-bottom-color: $primary;
@@ -52,6 +51,10 @@
 
   li {
     font-size: u(1.4rem);
+  }
+
+  &:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/scss/components/_tooltips.scss
+++ b/scss/components/_tooltips.scss
@@ -98,8 +98,11 @@
   }
 
   &.tooltip--left {
-    left: auto;
-    right: u(-14rem);
+    left: u(-2rem);
+
+    &::before {
+      left: u(2.8rem);
+    }
   }
 }
 


### PR DESCRIPTION
Includes a couple unrelated fixes I just caught:
- Actually calls the `trackerExists` function so Google Analytics gets added properly. Not sure if this has been causing problems or not
- Removes the `is-disabled` class from typeahead filter labels on enable