### PR TITLE
Fix "Clear all filters" behavior on certain checkboxes

### DIFF
--- a/js/dropdowns.js
+++ b/js/dropdowns.js
@@ -133,11 +133,13 @@ Dropdown.prototype.handleCheckboxRemoval = function($input) {
   var $label = $input.parent().find('label');
   var $button = this.$panel.find('button[data-label="' + $input.attr('id') +'"]');
 
-  $button.parent().append($input);
-  $button.parent().append($label);
-  $button.remove();
+  if ($button.length > 0) {
+    $button.parent().append($input);
+    $button.parent().append($label);
+    $button.remove();
 
-  $item.remove();
+    $item.remove();
+  }
 };
 
 Dropdown.prototype.handleRemoveClick = function(e, opts) {

--- a/js/filters.js
+++ b/js/filters.js
@@ -259,7 +259,7 @@ Filter.prototype.enable = function() {
       });
   });
   this.isEnabled = true;
-}
+};
 
 function SelectFilter(elm) {
   Filter.call(this, elm);

--- a/js/typeahead-filter.js
+++ b/js/typeahead-filter.js
@@ -57,6 +57,9 @@ var TypeaheadFilter = function(selector, dataset, allowText) {
   this.$field.on('keyup', this.handleKeypress.bind(this));
   this.$button.on('click', this.handleSubmit.bind(this));
 
+  $(document.body).on('tag:removed', this.removeCheckbox.bind(this));
+  $(document.body).on('tag:removeAll', this.removeAllCheckboxes.bind(this));
+
   this.typeaheadInit();
   this.disableButton();
 };
@@ -136,10 +139,19 @@ TypeaheadFilter.prototype.handleCheckbox = function(e) {
   $input.data('loaded-once', true);
 };
 
-TypeaheadFilter.prototype.removeCheckbox = function(e) {
+TypeaheadFilter.prototype.removeCheckbox = function(e, opts) {
   var $input = $(e.target);
 
+  // tag removal
+  if (opts) {
+    $input = this.$selected.find('#' + opts.key);
+  }
+
   $input.closest('li').remove();
+};
+
+TypeaheadFilter.prototype.removeAllCheckboxes = function() {
+  this.$selected.empty();
 };
 
 TypeaheadFilter.prototype.handleHover = function() {

--- a/tests/dropdowns.js
+++ b/tests/dropdowns.js
@@ -115,10 +115,9 @@ describe('dropdown', function() {
 
     it('remove tag also removes input', function() {
       this.dropdown.selectItem($('#A'));
-      this.dropdown.selectItem($('#B'));
       $(document.body).trigger('tag:removed', [{key: 'A'}]);
       var selectedItems = this.dropdown.$selected.find('.dropdown__item');
-      expect(selectedItems.length).to.equal(1);
+      expect(selectedItems.length).to.equal(0);
     });
 
     it('clear all tags removes all selected inputs', function() {

--- a/tests/dropdowns.js
+++ b/tests/dropdowns.js
@@ -113,13 +113,6 @@ describe('dropdown', function() {
       expect(dropdownItem.hasClass('is-checked')).to.be.false;
     });
 
-    it('remove tag also removes input', function() {
-      this.dropdown.selectItem($('#A'));
-      $(document.body).trigger('tag:removed', [{key: 'A'}]);
-      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
-      expect(selectedItems.length).to.equal(0);
-    });
-
     it('clear all tags removes all selected inputs', function() {
       this.dropdown.selectItem($('#A'));
       this.dropdown.selectItem($('#B'));

--- a/tests/dropdowns.js
+++ b/tests/dropdowns.js
@@ -28,146 +28,234 @@ describe('dropdown', function() {
     $('body').append(this.$fixture);
   });
 
-  beforeEach(function() {
-    this.$fixture.empty().append(
-      '<fieldset class="js-dropdown">' +
-        '<legend class="label">Election Years</legend>' +
-        '<ul class="dropdown__selected"></ul>' +
-        '<div class="dropdown">' +
-          '<button class="dropdown__button button--alt">More</button>' +
-          '<div id="cycle-dropdown" class="dropdown__panel" aria-hidden="true">' +
-            '<ul class="dropdown__list">' +
-              '<li class="dropdown__item">' +
-                '<input id="A" name="cycle" type="checkbox" value="A">' +
-                '<label id="label-A" class="dropdown__value" for="A">A</label>' +
-              '</li>' +
-              '<li class="dropdown__item">' +
-                '<input id="B" name="cycle" type="checkbox" value="B">' +
-                '<label id="label-B" class="dropdown__value" for="B">B</label>' +
-              '</li>' +
-            '</ul>' +
+  describe('standard dropdown', function() {
+    beforeEach(function() {
+      this.$fixture.empty().append(
+        '<fieldset class="js-dropdown">' +
+          '<legend class="label">Election Years</legend>' +
+          '<ul class="dropdown__selected"></ul>' +
+          '<div class="dropdown">' +
+            '<button class="dropdown__button button--alt">More</button>' +
+            '<div id="cycle-dropdown" class="dropdown__panel" aria-hidden="true">' +
+              '<ul class="dropdown__list">' +
+                '<li class="dropdown__item">' +
+                  '<input id="A" name="cycle" type="checkbox" value="A">' +
+                  '<label id="label-A" class="dropdown__value" for="A">A</label>' +
+                '</li>' +
+                '<li class="dropdown__item">' +
+                  '<input id="B" name="cycle" type="checkbox" value="B">' +
+                  '<label id="label-B" class="dropdown__value" for="B">B</label>' +
+                '</li>' +
+              '</ul>' +
+            '</div>' +
           '</div>' +
-        '</div>' +
-      '</fieldset>'
-    );
-    this.dropdown = new Dropdown('.js-dropdown');
+        '</fieldset>'
+      );
+      this.dropdown = new Dropdown('.js-dropdown');
+    });
+
+    it('initializes', function() {
+      expect(this.dropdown.isOpen).to.be.false;
+    });
+
+    it('shows', function() {
+      this.dropdown.show();
+      expect(isOpen(this.dropdown)).to.be.true;
+    });
+
+    it('hides', function() {
+      this.dropdown.hide();
+      expect(isClosed(this.dropdown)).to.be.true;
+    });
+
+    it('toggles', function() {
+      this.dropdown.$button.click();
+      expect(isOpen(this.dropdown)).to.be.true;
+      this.dropdown.$button.click();
+      expect(isClosed(this.dropdown)).to.be.true;
+    });
+
+    it('handles a check', function() {
+      var checkbox = this.dropdown.$panel.find('#A');
+      checkbox.click();
+      expect(checkbox.is(':checked')).to.be.true;
+    });
+
+    it('selects input when checked', function() {
+      this.dropdown.selectItem($('#A'));
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      var panelItems = this.dropdown.$panel.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(1);
+      expect(panelItems.length).to.equal(2);
+    });
+
+    it('select two inputs', function() {
+      this.dropdown.selectItem($('#A'));
+      this.dropdown.selectItem($('#B'));
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      var panelItems = this.dropdown.$panel.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(2);
+      expect(panelItems.length).to.equal(2);
+    });
+
+    it('selects dropdown item and make sure it is checked', function() {
+      this.dropdown.selectItem($('#A'));
+      var panelItems = this.dropdown.$panel.find('.dropdown__item');
+      expect(panelItems.find('.dropdown__item--selected').length).to.equal(1);
+      expect(panelItems.find('.dropdown__item--selected').hasClass('is-checked')).to.be.true;
+    });
+
+    it('unchecks an input', function() {
+      var checkbox = this.dropdown.$panel.find('#B');
+      checkbox.click();
+      checkbox.click();
+      var dropdownItem = this.dropdown.$panel.find('.dropdown__item--selected');
+      expect(dropdownItem.hasClass('is-checked')).to.be.false;
+    });
+
+    it('remove tag also removes input', function() {
+      this.dropdown.selectItem($('#A'));
+      this.dropdown.selectItem($('#B'));
+      $(document.body).trigger('tag:removed', [{key: 'A'}]);
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(1);
+    });
+
+    it('clear all tags removes all selected inputs', function() {
+      this.dropdown.selectItem($('#A'));
+      this.dropdown.selectItem($('#B'));
+      $(document.body).trigger('tag:removeAll');
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      var panelItems = this.dropdown.$panel.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(0);
+      expect(panelItems.length).to.equal(2);
+    });
+
+    it('removes an unchecked input', function() {
+      var checkbox = this.dropdown.$panel.find('#B');
+      checkbox.click();
+      checkbox.click();
+      expect(checkbox.is(':checked')).to.be.false;
+      this.dropdown.handleCheckboxRemoval(checkbox);
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(0);
+    });
+
+    it('focuses next input', function() {
+      this.dropdown.selectItem($('#A'));
+      expect(document.activeElement).to.equal($('#B').get(0));
+    });
+
+    it('focuses previous input when selecting the bottom item', function() {
+      this.dropdown.selectItem($('#B'));
+      expect(document.activeElement).to.equal($('#A').get(0));
+    });
+
+    it('calls remove on selecting the last item', function() {
+      sinon.spy(this.dropdown, 'removePanel');
+      this.dropdown.selectItem($('#A'));
+      expect(this.dropdown.removePanel).to.have.not.been.called;
+      this.dropdown.selectItem($('#B'));
+      expect(this.dropdown.removePanel).to.have.been.called;
+    });
+
+    it('removes the panel', function() {
+      this.dropdown.removePanel();
+      expect(this.dropdown.$body.find('.dropdown__panel').length).to.equal(0);
+      expect(this.dropdown.$body.find('.dropdown__button').length).to.equal(0);
+    });
+
+    it('removes the panel on init if empty', function() {
+      this.$fixture.empty().append(
+        '<fieldset class="js-dropdown">' +
+          '<legend class="label">Election Years</legend>' +
+          '<ul class="dropdown__selected"></ul>' +
+          '<div class="dropdown">' +
+            '<button class="dropdown__button button--alt">More</button>' +
+            '<div id="cycle-dropdown" class="dropdown__panel" aria-hidden="true"></div>' +
+          '</div>' +
+        '</fieldset>'
+      );
+      sinon.spy(Dropdown.prototype, 'removePanel');
+      var dropdown = new Dropdown('.js-dropdown');
+      expect(Dropdown.prototype.removePanel).to.have.been.called;
+    });
+
+    it('hides when clicking somewhere else', function() {
+      this.dropdown.show();
+      this.dropdown.handleClickAway({target: 'other'});
+      expect(isClosed(this.dropdown)).to.be.true;
+    });
+
+    it('hides when focusing somewhere else', function() {
+      this.dropdown.show();
+      this.dropdown.handleFocusAway({target: 'other'});
+      expect(isClosed(this.dropdown)).to.be.true;
+    });
+
+    it('hides on ESC', function(){
+      this.dropdown.show();
+      this.dropdown.handleKeyup({keyCode: 27});
+      expect(isClosed(this.dropdown)).to.be.true;
+    });
   });
 
-  it('initializes', function() {
-    expect(this.dropdown.isOpen).to.be.false;
-  });
+  describe('non-removable checkboxes and dropdown', function() {
+    beforeEach(function() {
+      this.$fixture.empty().append(
+        '<fieldset class="js-dropdown">' +
+          '<legend class="label">Political Party</legend>' +
+          '<ul class="dropdown__selected">' +
+            '<li class="dropdown__item">' +
+              '<input id="party-DEM" name="party" type="checkbox" value="DEM" tabindex="0">' +
+              '<label class="dropdown__value" for="party-DEM">Democratic Party</label>' +
+            '</li>' +
+            '<li class="dropdown__item">' +
+              '<input id="party-REP" name="party" type="checkbox" value="REP" tabindex="0">' +
+              '<label class="dropdown__value" for="party-REP">Republican Party</label>' +
+            '</li>' +
+          '</ul>' +
+          '<div class="dropdown">' +
+            '<button class="dropdown__button button--alt">More</button>' +
+            '<div id="cycle-dropdown" class="dropdown__panel" aria-hidden="true">' +
+              '<ul class="dropdown__list">' +
+                '<li class="dropdown__item">' +
+                  '<input id="A" name="cycle" type="checkbox" value="A">' +
+                  '<label id="label-A" class="dropdown__value" for="A">A</label>' +
+                '</li>' +
+                '<li class="dropdown__item">' +
+                  '<input id="B" name="cycle" type="checkbox" value="B">' +
+                  '<label id="label-B" class="dropdown__value" for="B">B</label>' +
+                '</li>' +
+              '</ul>' +
+            '</div>' +
+          '</div>' +
+        '</fieldset>'
+      );
+      this.dropdown = new Dropdown('.js-dropdown');
+    });
 
-  it('shows', function() {
-    this.dropdown.show();
-    expect(isOpen(this.dropdown)).to.be.true;
-  });
+    it('select dropdown item and adds input to selected', function() {
+      this.dropdown.selectItem($('#A'));
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      var panelItems = this.dropdown.$panel.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(3);
+      expect(panelItems.length).to.equal(2);
+    });
 
-  it('hides', function() {
-    this.dropdown.hide();
-    expect(isClosed(this.dropdown)).to.be.true;
-  });
+    it('removal of tag does not delete non-removable checkbox', function() {
+      $(document.body).trigger('tag:removed', [{key: 'party-DEM'}]);
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(2);
+    });
 
-  it('toggles', function() {
-    this.dropdown.$button.click();
-    expect(isOpen(this.dropdown)).to.be.true;
-    this.dropdown.$button.click();
-    expect(isClosed(this.dropdown)).to.be.true;
-  });
-
-  it('handles a check', function() {
-    var checkbox = this.dropdown.$panel.find('#A');
-    checkbox.click();
-    expect(checkbox.is(':checked')).to.be.true;
-  });
-
-  it('selects input when checked', function() {
-    this.dropdown.selectItem($('#A'));
-    var selectedItems = this.dropdown.$selected.find('.dropdown__item');
-    var panelItems = this.dropdown.$panel.find('.dropdown__item');
-    expect(selectedItems.length).to.equal(1);
-    expect(panelItems.length).to.equal(2);
-  });
-
-  it('selects dropdown item and make sure it is checked', function() {
-    this.dropdown.selectItem($('#A'));
-    var panelItems = this.dropdown.$panel.find('.dropdown__item');
-    expect(panelItems.find('.dropdown__item--selected').length).to.equal(1);
-    expect(panelItems.find('.dropdown__item--selected').hasClass('is-checked')).to.be.true;
-  });
-
-  it('unchecks an input', function() {
-    var checkbox = this.dropdown.$panel.find('#B');
-    checkbox.click();
-    checkbox.click();
-    var dropdownItem = this.dropdown.$panel.find('.dropdown__item--selected');
-    expect(dropdownItem.hasClass('is-checked')).to.be.false;
-  });
-
-  it('removes an unchecked input', function() {
-    var checkbox = this.dropdown.$panel.find('#B');
-    checkbox.click();
-    checkbox.click();
-    expect(checkbox.is(':checked')).to.be.false;
-    this.dropdown.handleCheckboxRemoval(checkbox);
-    var selectedItems = this.dropdown.$selected.find('.dropdown__item');
-    expect(selectedItems.length).to.equal(0);
-  });
-
-  it('focuses next input', function() {
-    this.dropdown.selectItem($('#A'));
-    expect(document.activeElement).to.equal($('#B').get(0));
-  });
-
-  it('focuses previous input when selecting the bottom item', function() {
-    this.dropdown.selectItem($('#B'));
-    expect(document.activeElement).to.equal($('#A').get(0));
-  });
-
-  it('calls remove on selecting the last item', function() {
-    sinon.spy(this.dropdown, 'removePanel');
-    this.dropdown.selectItem($('#A'));
-    expect(this.dropdown.removePanel).to.have.not.been.called;
-    this.dropdown.selectItem($('#B'));
-    expect(this.dropdown.removePanel).to.have.been.called;
-  });
-
-  it('removes the panel', function() {
-    this.dropdown.removePanel();
-    expect(this.dropdown.$body.find('.dropdown__panel').length).to.equal(0);
-    expect(this.dropdown.$body.find('.dropdown__button').length).to.equal(0);
-  });
-
-  it('removes the panel on init if empty', function() {
-    this.$fixture.empty().append(
-      '<fieldset class="js-dropdown">' +
-        '<legend class="label">Election Years</legend>' +
-        '<ul class="dropdown__selected"></ul>' +
-        '<div class="dropdown">' +
-          '<button class="dropdown__button button--alt">More</button>' +
-          '<div id="cycle-dropdown" class="dropdown__panel" aria-hidden="true"></div>' +
-        '</div>' +
-      '</fieldset>'
-    );
-    sinon.spy(Dropdown.prototype, 'removePanel');
-    var dropdown = new Dropdown('.js-dropdown');
-    expect(Dropdown.prototype.removePanel).to.have.been.called;
-  });
-
-  it('hides when clicking somewhere else', function() {
-    this.dropdown.show();
-    this.dropdown.handleClickAway({target: 'other'});
-    expect(isClosed(this.dropdown)).to.be.true;
-  });
-
-  it('hides when focusing somewhere else', function() {
-    this.dropdown.show();
-    this.dropdown.handleFocusAway({target: 'other'});
-    expect(isClosed(this.dropdown)).to.be.true;
-  });
-
-  it('hides on ESC', function(){
-    this.dropdown.show();
-    this.dropdown.handleKeyup({keyCode: 27});
-    expect(isClosed(this.dropdown)).to.be.true;
+    it('clear all tags only removes removable selected inputs', function() {
+      this.dropdown.selectItem($('#A'));
+      var selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(3);
+      $(document.body).trigger('tag:removeAll');
+      selectedItems = this.dropdown.$selected.find('.dropdown__item');
+      expect(selectedItems.length).to.equal(2);
+    });
   });
 });


### PR DESCRIPTION
- Removing tag or "clear all filters" on set checkboxes above dropdowns will uncheck, but not delete the checkbox entirely.
- Removes all generated checkboxes from typeahead inputs upon clicking "clear all filters"

Resolves #476 

Ready for review, cc: @noahmanger 