### PR TITLE
Better mobile layout for legal search

### DIFF
--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -86,6 +86,7 @@
     border-collapse: collapse;
     display: table;
     table-layout: fixed;
+    width: 100%;
   }
 
   .legal-search-results__header-row {

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -33,38 +33,8 @@
 // Styleguide components.search-results-legal
 
 
-.legal-search-results__header-row {
-  border-bottom: 1px solid $primary;
-  font-family: $sans-serif;
-  font-weight: 600;
-
-}
-
-.legal-search-results__header {
-  display: none; // Hide all but the first header cell
-  padding: u(0.5rem 1rem);
-  text-align: left;
-
-  &:first-child {
-    display: table-cell;
-  }
-}
-
 .legal-search-results__subtext {
   font-weight: normal;
-}
-
-.legal-search-result {
-  border-bottom: 1px solid $neutral;
-  padding: u(1rem);
-
-  &:last-child {
-    border-bottom: none;
-  }
-
-  &:nth-child(even) {
-    background-color: rgba($gray-lightest, .5);
-  }
 }
 
 .legal-search-result__name {
@@ -77,45 +47,5 @@
 
   em {
     @include t-highlight;
-  }
-}
-
-// Table-style display
-@include media($med) {
-  .legal-search-results {
-    border-collapse: collapse;
-    display: table;
-    table-layout: fixed;
-    width: 100%;
-  }
-
-  .legal-search-results__header-row {
-    display: table-header-group;
-  }
-
-  .legal-search-results__header {
-    display: table-cell;
-  }
-
-  .legal-search-results__list {
-    display: table-row-group;
-  }
-
-  .legal-search-result {
-    display: table-row;
-  }
-
-  .legal-search-result__field {
-    display: table-cell;
-    padding: u(1rem);
-  }
-
-  .legal-search-results__header,
-  .legal-search-result__field {
-    border-left: 1px solid $neutral;
-
-    &:first-child {
-      border-left: none;
-    }
   }
 }

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -1,7 +1,6 @@
 // Legal search
 //
-// Styles for legal search results. On desktop, they take a tabular layout but
-// compress to a more compact display for mobile.
+// Styles for legal search results.
 //
 // Markup:
 // <div class="legal-search-results">

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -3,16 +3,16 @@
 // Styles for legal search results.
 //
 // Markup:
-// <div class="legal-search-results">
-//   <div class="legal-search-results__header-row">
-//     <div class="legal-search-results__header cell--15">Section</div>
-//     <div class="legal-search-results__header">Description</div>
+// <div class="simple-table simple-table--display simple-table--responsive">
+//   <div class="simple-table__header">
+//     <div class="simple-table__header-cell">Section</div>
+//     <div class="simple-table__header-cell">Description <span class="simple-table__header-subtext">| Hit</span></div>
 //   </div>
-//   <div class="legal-search-results__list">
-//     <div class="legal-search-result">
-//       <div class="legal-search-result__field"><a title="" href="/regulations/5-6/2016-annual-5#5-6">§ 5.6</a></div>
-//       <div class="legal-search-result__field">
-//         <strong>Fees.</strong>
+//   <div class="simple-table__row-group">
+//     <div class="simple-table__row legal-search-result">
+//       <div class="simple-table__cell"><a title="" href="/regulations/5-6/2016-annual-5#5-6">§ 5.6</a></div>
+//       <div class="simple-table__cell">
+//         <div class="legal-search-result__name">Fees.</div>
 //         <div class="t-serif legal-search-result__hit">
 //           … per copy, including reproduction and binding).  Cost ($.0006 per
 //           <em>Computer</em> Resource Unit Utilized—CRU … ) to process the
@@ -31,10 +31,6 @@
 //
 // Styleguide components.search-results-legal
 
-
-.legal-search-results__subtext {
-  font-weight: normal;
-}
 
 .legal-search-result__name {
   font-family: $sans-serif;

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -1,8 +1,76 @@
 // Legal search
 //
-// Styles for legal search results.
+// Styles for legal search results. On desktop, they take a tabular layout but
+// compress to a more compact display for mobile.
+//
+// Markup:
+// <div class="legal-search-results">
+//   <div class="legal-search-results__header-row">
+//     <div class="legal-search-results__header cell--15">Section</div>
+//     <div class="legal-search-results__header">Description</div>
+//   </div>
+//   <div class="legal-search-results__list">
+//     <div class="legal-search-result">
+//       <div class="legal-search-result__field"><a title="" href="/regulations/5-6/2016-annual-5#5-6">§ 5.6</a></div>
+//       <div class="legal-search-result__field">
+//         <strong>Fees.</strong>
+//         <div class="t-serif legal-search-result__hit">
+//           … per copy, including reproduction and binding).  Cost ($.0006 per
+//           <em>Computer</em> Resource Unit Utilized—CRU … ) to process the
+//           request plus the cost of the <em>computer</em> tape ($25) and
+//           professional staff time (see … Research Time). The cost varies based
+//           upon request.  No charge for 20 or fewer requests for
+//           <em>computer</em> … ID numbers will cost $2.00 for each ID number
+//           requested. Other <em>computer</em> index requests for more … than 20
+//           ID numbers will cost $.0006 per CRU (<em>Computer</em> Resource Unit)
+//           utilized. Name Search—A <em>computer</em> …
+//         </div>
+//       </div>
+//     </div>
+//   </div>
+// </div>
 //
 // Styleguide components.search-results-legal
+
+
+.legal-search-results__header-row {
+  border-bottom: 1px solid $primary;
+  font-family: $sans-serif;
+  font-weight: 600;
+
+}
+
+.legal-search-results__header {
+  display: none; // Hide all but the first header cell
+  padding: u(0.5rem 1rem);
+  text-align: left;
+
+  &:first-child {
+    display: table-cell;
+  }
+}
+
+.legal-search-results__subtext {
+  font-weight: normal;
+}
+
+.legal-search-result {
+  border-bottom: 1px solid $neutral;
+  padding: u(1rem);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:nth-child(even) {
+    background-color: rgba($gray-lightest, .5);
+  }
+}
+
+.legal-search-result__name {
+  font-family: $sans-serif;
+  font-weight: 600;
+}
 
 .legal-search-result__hit {
   font-style: italic;
@@ -12,6 +80,41 @@
   }
 }
 
-.legal-search-result__display-all {
-  margin: 0.5em 0;
+// Table-style display
+@include media($med) {
+  .legal-search-results {
+    border-collapse: collapse;
+    display: table;
+    table-layout: fixed;
+  }
+
+  .legal-search-results__header-row {
+    display: table-header-group;
+  }
+
+  .legal-search-results__header {
+    display: table-cell;
+  }
+
+  .legal-search-results__list {
+    display: table-row-group;
+  }
+
+  .legal-search-result {
+    display: table-row;
+  }
+
+  .legal-search-result__field {
+    display: table-cell;
+    padding: u(1rem);
+  }
+
+  .legal-search-results__header,
+  .legal-search-result__field {
+    border-left: 1px solid $neutral;
+
+    &:first-child {
+      border-left: none;
+    }
+  }
 }

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -2,12 +2,16 @@
 //
 // Simple table with rules
 //
+// .simple-table                - Simple table with rules.
+// .simple-table--responsive    - Display a table on larger screens, collapse to compact display on small screens.
+// .simple-table--display       - More padding with vertical rules and alternating background color similar to `.datatables`.
+//
 // Markup:
-// <table class="simple-table">
+// <table class="simple-table {{ modifier_class }}">
 //     <thead class="simple-table__header">
 //         <tr>
-//             <th>Dates covered</th>
-//             <th>Due</th>
+//             <th class="simple-table__header-cell">Dates covered</th>
+//             <th class="simple-table__header-cell">Due</th>
 //         </tr>
 //     </thead>
 //     <tbody>
@@ -22,7 +26,9 @@
 //     </tbody>
 // </table>
 //
+//
 // Styleguide components.simple-table
+
 
 .simple-table {
   border-color: $primary;
@@ -35,7 +41,10 @@
 
 .simple-table__header {
   border-bottom: 1px solid $primary;
+  font-weight: 600;
+  text-align: left;
 
+  .simple-table__header-cell,
   th {
     padding: u(.5rem 0);
   }
@@ -43,19 +52,14 @@
 
 .simple-table__cell {
   padding: u(1rem 0);
-  border-bottom: 1px solid $neutral;
   vertical-align: top;
-
-  &:only-child {
-    border-bottom: none;
-  }
 }
 
 .simple-table__row {
+  border-bottom: 1px solid $neutral;
+
   &:last-of-type {
-    .simple-table__cell {
-      border-bottom: none;
-    }
+    border-bottom: none;
   }
 }
 
@@ -66,37 +70,22 @@ h3 + .simple-table {
   margin-top: u(-1rem);
 }
 
-.table {
-  .th {
-    text-align: left;
+.simple-table--display {
+  &.simple-table {
+    color: $base;
+    border: none;
+    margin: 0;
   }
 
-  .tr {
-    border-bottom: 1px solid $neutral;
-
-    &:last-child {
-      border-bottom: none;
-    }
-
-  }
-}
-
-.table--display {
-  .thead {
-    border-bottom: 1px solid $primary;
-    font-family: $sans-serif;
-    font-weight: 600;
-  }
-
-  .th {
+  .simple-table__header-cell {
     padding: u(0.5rem 1rem);
   }
 
-  .td {
+  .simple-table__cell {
     padding: u(1rem);
   }
 
-  .tr {
+  .simple-table__row {
     padding: u(1rem);
 
     &:nth-child(even) {
@@ -104,19 +93,27 @@ h3 + .simple-table {
     }
   }
 
-  .th,
-  .td {
+  .simple-table__cell {
     border-left: 1px solid $neutral;
 
     &:first-child {
       border-left: none;
     }
   }
+
+  @include media($med) {
+    // We need to restore the padding on larger screens when combined with .simple-table--responsive
+    &.simple-table--responsive {
+      .simple-table__cell {
+        padding: u(1rem);
+      }
+    }
+  }
 }
 
 // Table-style display
-.table--responsive {
-  .th {
+.simple-table--responsive {
+  .simple-table__header-cell {
     display: none; // Hide all but the first header cell
 
     &:first-child {
@@ -124,40 +121,40 @@ h3 + .simple-table {
     }
   }
 
-  .td {
+  .simple-table__cell {
     padding: 0;
   }
 
-  .td,
-  .th {
+  .simple-table__cell,
+  .simple-table__header-cell {
     border-left: none;
   }
 
   @include media($med) {
-    .table {
+    & {
       border-collapse: collapse;
       display: table;
       table-layout: fixed;
       width: 100%;
     }
 
-    .thead {
+    .simple-table__header {
       display: table-header-group;
     }
 
-    .th {
+    .simple-table__header-cell {
       display: table-cell;
     }
 
-    .tbody {
+    .simple-table__row-group {
       display: table-row-group;
     }
 
-    .tr {
+    .simple-table__row {
       display: table-row;
     }
 
-    .td {
+    .simple-table__cell {
       display: table-cell;
     }
   }

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -86,7 +86,12 @@ h3 + .simple-table {
   }
 
   .simple-table__cell {
+    border-left: 1px solid $neutral;
     padding: u(1rem);
+
+    &:first-child {
+      border-left: none;
+    }
   }
 
   .simple-table__row {
@@ -94,14 +99,6 @@ h3 + .simple-table {
 
     &:nth-child(even) {
       background-color: rgba($gray-lightest, .5);
-    }
-  }
-
-  .simple-table__cell {
-    border-left: 1px solid $neutral;
-
-    &:first-child {
-      border-left: none;
     }
   }
 

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -11,7 +11,7 @@
 //     <thead class="simple-table__header">
 //         <tr>
 //             <th class="simple-table__header-cell">Dates covered</th>
-//             <th class="simple-table__header-cell">Due</th>
+//             <th class="simple-table__header-cell">Due <span class="simple-table__header-subtext">| Notes</span></th>
 //         </tr>
 //     </thead>
 //     <tbody>
@@ -47,6 +47,10 @@
   .simple-table__header-cell,
   th {
     padding: u(.5rem 0);
+  }
+
+  .simple-table__header-subtext {
+    font-weight: normal;
   }
 }
 

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -65,3 +65,100 @@
 h3 + .simple-table {
   margin-top: u(-1rem);
 }
+
+.table {
+  .th {
+    text-align: left;
+  }
+
+  .tr {
+    border-bottom: 1px solid $neutral;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+  }
+}
+
+.table--display {
+  .thead {
+    border-bottom: 1px solid $primary;
+    font-family: $sans-serif;
+    font-weight: 600;
+  }
+
+  .th {
+    padding: u(0.5rem 1rem);
+  }
+
+  .td {
+    padding: u(1rem);
+  }
+
+  .tr {
+    padding: u(1rem);
+
+    &:nth-child(even) {
+      background-color: rgba($gray-lightest, .5);
+    }
+  }
+
+  .th,
+  .td {
+    border-left: 1px solid $neutral;
+
+    &:first-child {
+      border-left: none;
+    }
+  }
+}
+
+// Table-style display
+.table--responsive {
+  .th {
+    display: none; // Hide all but the first header cell
+
+    &:first-child {
+      display: table-cell;
+    }
+  }
+
+  .td {
+    padding: 0;
+  }
+
+  .td,
+  .th {
+    border-left: none;
+  }
+
+  @include media($med) {
+    .table {
+      border-collapse: collapse;
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+    }
+
+    .thead {
+      display: table-header-group;
+    }
+
+    .th {
+      display: table-cell;
+    }
+
+    .tbody {
+      display: table-row-group;
+    }
+
+    .tr {
+      display: table-row;
+    }
+
+    .td {
+      display: table-cell;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part of the work for legal statutes https://github.com/18F/fec-eregs/issues/210.  Uses `display: table-cell` to switch between a tabular layout on larger screens and a compressed layout on mobile, taking into consideration some of the pattern discussion from https://github.com/18F/fec-style/issues/318.

@noahmanger let me know what you think. Wondering if it makes sense to make the `display: table` styles more generic, like using classnames like `.table`, `.thead`, `.td`, etc.

You can see this in the web app https://github.com/18F/openFEC-web-app/pull/1531

## Screenshots

**Before**
<img alt="screenshot from 2016-08-18 12-59-13" src="https://cloud.githubusercontent.com/assets/509703/17788688/d08a2850-6543-11e6-9918-51599f5de167.png" width="320">

**After**
<img alt="screenshot from 2016-08-18 13-00-23" src="https://cloud.githubusercontent.com/assets/509703/17788711/e0122d4a-6543-11e6-86a0-7e58b964b6eb.png" width="320">

cc @jenniferthibault @noahmanger 

