### PR TITLE
Fix election filter

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -489,6 +489,7 @@ function ElectionFilter(elm) {
   this.$cycle = this.$body.find('input[type="hidden"][name="' + this.cycleName + '"]');
   this.$full = this.$body.find('input[type="hidden"][name="' + this.fullName + '"]');
 
+  this.loadedOnce = false;
   this.$election.on('change', this.handleElectionChange.bind(this));
   this.$cycles.on('change', this.handleCycleChange.bind(this));
 
@@ -551,13 +552,15 @@ ElectionFilter.prototype.setTag = function() {
   var election = this.$election.val();
   var cycle = this.$cycles.find(':checked').data('display-value');
   var value = election + ' election: ' + cycle;
-  this.$election.trigger('filter:added', [
+  var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';
+  this.$election.trigger(eventName, [
     {
       key: 'election',
       value: value,
       nonremovable: true
     }
   ]);
+  this.loadedOnce = true;
 };
 
 /* MultiFilters used when there are multiple filters that share the

--- a/tests/filter.js
+++ b/tests/filter.js
@@ -244,12 +244,26 @@ describe('filter set', function() {
     });
 
     it('sets a tag', function() {
+      this.filter.loadedOnce = false;
       this.filter.$election.val('2016');
       this.filter.setTag();
       expect(this.trigger).to.have.been.calledWith('filter:added', [
         {
           key: 'election',
           value: '2016 election: 2013-2014',
+          nonremovable: true
+        }
+      ]);
+    });
+
+    it('renames a tag if it already exitss', function() {
+      this.filter.loadedOnce = true;
+      this.filter.$election.val('2012');
+      this.filter.setTag();
+      expect(this.trigger).to.have.been.calledWith('filter:renamed', [
+        {
+          key: 'election',
+          value: '2012 election: 2013-2014',
           nonremovable: true
         }
       ]);


### PR DESCRIPTION
## Summary
Fixes the `ElectionFilter` so that it only fires the `filter:added` event first, and then `filter:renamed` after. This prevents it from generating multiple tags.

Resolves https://github.com/18F/openFEC-web-app/issues/1380#issuecomment-241424660

## Screenshots
![demo](http://g.recordit.co/RVKBYY7qtL.gif)

cc @xtine 
