### PR TITLE
Financial range tag

### DIFF
--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -126,7 +126,12 @@ Filter.prototype.handleChange = function(e) {
     loadedOnce = $input.data('loaded-once') || false;
 
     // set focus to button
-    $input.next().focus();
+    if ($input.parent().hasClass('range__input')) {
+      $input.parent().next().focus();
+    }
+    else {
+      $input.next().focus();
+    }
 
     if ($input.data('had-value') && value.length > 0) {
       eventName = 'filter:renamed';

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -98,6 +98,7 @@ Filter.prototype.handleChange = function(e) {
   var type = $input.attr('type') || 'text';
   var prefix = $input.data('prefix');
   var suffix = $input.data('suffix');
+  var range = $input.data('range') || 'false';
   var id = $input.attr('id');
   var loadedOnce,
       eventName,
@@ -151,10 +152,10 @@ Filter.prototype.handleChange = function(e) {
   if (prefix) {
     prefix = prefix === '$' ? prefix : prefix + ' ';
 
-    value = prefix + value;
+    value = '<span class="prefix">' + prefix + '</span>' + value;
   }
   if (suffix) {
-    value = value + ' ' + suffix;
+    value = value + '<span class="suffix"> ' + suffix + '</span>';
   }
 
   $input.trigger(eventName, [
@@ -162,7 +163,8 @@ Filter.prototype.handleChange = function(e) {
       key: id,
       value: value,
       loadedOnce: loadedOnce,
-      name: this.name
+      name: this.name,
+      range: range
     }
   ]);
 

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -62,6 +62,11 @@ TagList.prototype.addTag = function(e, opts) {
   var $tagCategory = this.$list.find('[data-tag-category="' + opts.name + '"]');
   this.removeTag(opts.key, false);
 
+  if (opts.range === 'min' || opts.range === 'max') {
+    this.addRangeTag(tag, $tagCategory, opts);
+    return;
+  }
+
   if ($tagCategory.length > 0) {
     $tagCategory.append(tag);
   }
@@ -79,6 +84,18 @@ TagList.prototype.addTag = function(e, opts) {
   }
 };
 
+TagList.prototype.addRangeTag = function(tag, $tagCategory, opts) {
+  if ($tagCategory.length > 0 && opts.range == 'min') {
+    $tagCategory.addClass('tag__category--range').prepend(tag);
+  }
+  else if ($tagCategory.length > 0 && opts.range == 'max') {
+    $tagCategory.addClass('tag__category--range').append(tag);
+  }
+  else {
+    this.$list.append('<li data-tag-category="' + opts.name + '" class="tag__category">' + tag + '</li>');
+  }
+};
+
 TagList.prototype.removeTag = function(key, emit) {
   var $tag = this.$list.find('[data-id="' + key + '"]');
   var $tagCategory = $tag.parent();
@@ -89,6 +106,10 @@ TagList.prototype.removeTag = function(key, emit) {
     }
 
     $tag.remove();
+
+    if ($tagCategory.hasClass('tag__category--range')) {
+      $tagCategory.removeClass('tag__category--range');
+    }
 
     if ($tagCategory.is(':empty')) {
       $tagCategory.remove();

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -62,13 +62,8 @@ TagList.prototype.addTag = function(e, opts) {
   var $tagCategory = this.$list.find('[data-tag-category="' + opts.name + '"]');
   this.removeTag(opts.key, false);
 
-  if (opts.range === 'min' || opts.range === 'max') {
-    this.addRangeTag(tag, $tagCategory, opts);
-    return;
-  }
-
   if ($tagCategory.length > 0) {
-    $tagCategory.append(tag);
+    this.addTagItem($tagCategory, tag, opts);
   }
   else {
     this.$list.append('<li data-tag-category="' + opts.name + '" class="tag__category">' + tag + '</li>');
@@ -84,15 +79,15 @@ TagList.prototype.addTag = function(e, opts) {
   }
 };
 
-TagList.prototype.addRangeTag = function(tag, $tagCategory, opts) {
-  if ($tagCategory.length > 0 && opts.range == 'min') {
+TagList.prototype.addTagItem = function($tagCategory, tag, opts) {
+  if (opts.range == 'min') {
     $tagCategory.addClass('tag__category--range').prepend(tag);
   }
-  else if ($tagCategory.length > 0 && opts.range == 'max') {
+  else if (opts.range == 'max') {
     $tagCategory.addClass('tag__category--range').append(tag);
   }
   else {
-    this.$list.append('<li data-tag-category="' + opts.name + '" class="tag__category">' + tag + '</li>');
+    $tagCategory.append(tag);
   }
 };
 

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -60,6 +60,26 @@
   }
 }
 
+.tag__category--range {
+  .tag__item {
+    margin-right: u(2rem);
+
+    .suffix {
+      display: none;
+    }
+
+    .tag__remove {
+      padding-left: u(1rem);
+    }
+
+    &::after {
+      content: '-';
+      padding: 0;
+      right: u(-1.5rem);
+    }
+  }
+}
+
 .tag__remove {
   @include u-icon-bg($x, $primary);
   background-size: u(1.4rem);


### PR DESCRIPTION
Improved financial range tags, for 18F/openfec-web-app#1542.
- Setting one financial tag remains the same
- Setting an additional financial tag shows changed tag design with range inputs separated by a dash and in sequential order.
- Removing a financial tag in a range turns tag back to original singular form.
- Tags update in place

Also clicking enter to change a financial input will change focus to button like existing text input behavior.

![7bwrrgllym](https://cloud.githubusercontent.com/assets/24054/17977274/f36cc166-6ae8-11e6-910e-e5c5bd762178.gif)

Requires 18F/openfec-web-app#1546

cc: @noahmanger 