### PR TITLE
Ensure toggle filters add tags

### DIFF
--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -8,6 +8,8 @@ var Filter = require('./filter-base.js').Filter;
 /* ToggleFilter that has to fire a custom event */
 function ToggleFilter(elm) {
   Filter.call(this, elm);
+  this.$elm.on('change', this.handleChange.bind(this));
+  this.setInitialValue();
 }
 
 ToggleFilter.prototype = Object.create(Filter.prototype);
@@ -19,19 +21,26 @@ ToggleFilter.prototype.fromQuery = function(query) {
 
 ToggleFilter.prototype.handleChange = function(e) {
   var value = $(e.target).val();
-  var id = this.$input.attr('id');
   var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';
   this.$elm.trigger(eventName, [
     {
-      key: id,
+      key: this.name + '-toggle',
       value: 'Data type: ' + value,
-      loadedOnce: this.loadedOnce,
+      loadedOnce: this.loadedOnce || false,
       name: this.name,
       nonremovable: true
     }
   ]);
 
   this.loadedOnce = true;
+};
+
+ToggleFilter.prototype.setInitialValue = function() {
+  // If a toggle is checked by default in the DOM, call handleChange()
+  var $checked = this.$elm.find('input:checked');
+  if ($checked.length > 0) {
+    this.handleChange({target: $checked});
+  }
 };
 
 module.exports = {ToggleFilter: ToggleFilter};

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+var expect = chai.expect;
+chai.use(sinonChai);
+
+var $ = require('jquery');
+
+require('./setup')();
+
+var ToggleFilter = require('../js/toggle-filter').ToggleFilter;
+var DOM = '<fieldset class="js-filter">' +
+            '<legend class="label">Data type</legend>' +
+            '<label for="processed">' +
+              '<input type="radio" value="processed" id="processed" checked name="data_type">' +
+              '<span>Processed data</span>' +
+            '</label>' +
+            '<label for="efiling">' +
+              '<input type="radio" value="efiling" id="efiling" name="data_type">' +
+              '<span>eFilings</span>' +
+            '</label>' +
+          '</fieldset>';
+
+describe('checkbox filters', function() {
+  before(function() {
+    this.$fixture = $('<div id="fixtures"></div>');
+    $('body').append(this.$fixture);
+  });
+
+  beforeEach(function() {
+    this.$fixture.empty().append(DOM);
+    this.handleChange = sinon.spy(ToggleFilter.prototype, 'handleChange');
+    this.filter = new ToggleFilter(this.$fixture.find('.js-filter'));
+  });
+
+  afterEach(function() {
+    ToggleFilter.prototype.handleChange.restore();
+  });
+
+  it('locates dom elements', function() {
+    expect(this.filter.$elm.is('#fixtures .js-filter')).to.be.true;
+    expect(this.filter.$input.is('#fixtures input')).to.be.true;
+  });
+
+  it('sets its initial state', function() {
+    expect(this.filter.name).to.equal('data_type');
+    expect(this.filter.fields).to.deep.equal(['data_type']);
+  });
+
+  it('pulls values from the query', function() {
+    var query = {'data_type': 'efiling'};
+    this.filter.fromQuery(query);
+    expect(this.filter.$elm.find('#processed').is(':checked')).to.be.false;
+    expect(this.filter.$elm.find('#efiling').is(':checked')).to.be.true;
+  });
+
+  it('calls handleChange() on initial load', function() {
+    expect(this.handleChange).to.have.been.called;
+  });
+
+  it('calls handleChange() on change', function() {
+    this.filter.$elm.find('#efiling').prop('checked', true).change();
+    expect(this.handleChange).to.have.been.called;
+  });
+
+  describe('handleChange()', function() {
+    beforeEach(function() {
+      this.trigger = sinon.spy($.prototype, 'trigger');
+      this.$fixture.empty().append(DOM);
+      this.filter = new ToggleFilter(this.$fixture.find('.js-filter'));
+    });
+
+    afterEach(function() {
+      $.prototype.trigger.restore();
+    });
+
+    it('sets loaded-once on the input after loading', function() {
+      expect(this.filter.loadedOnce).to.be.true;
+    });
+
+    it('triggers the add event on initial setting of toggle', function() {
+      expect(this.trigger).to.have.been.calledWith('filter:added', [
+        {
+          key: 'data_type-toggle',
+          value: 'Data type: processed',
+          loadedOnce: false,
+          name: 'data_type',
+          nonremovable: true
+        }
+      ]);
+    });
+
+    it('triggers rename event on changing the toggle', function() {
+      this.$fixture.find('#efiling').prop('checked', true).change();
+      expect(this.trigger).to.have.been.calledWith('filter:renamed', [
+        {
+          key: 'data_type-toggle',
+          value: 'Data type: efiling',
+          loadedOnce: true,
+          name: 'data_type',
+          nonremovable: true
+        }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes a bug where the toggle filters weren't triggering `filter:added` events. This fixes that bug and adds test coverage.

Resolves https://github.com/18F/fec-style/issues/491