### PR TITLE
Styles for future archived case icon

### DIFF
--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -44,3 +44,15 @@
     @include t-highlight;
   }
 }
+
+.legal-mur__archive {
+  font-size: u(1.3rem);
+  margin-top: u(0.8rem);
+
+  .legal-mur__archive-icon {
+    @include u-icon($file-box, $base, 1.5rem, 1.5rem, 100%);
+    display: inline-block;
+    margin-right: u(0.7rem);
+    vertical-align: top;
+  }
+}


### PR DESCRIPTION
## Summary

This adds the styles for the archived case indicator for MURs, as per https://github.com/18F/fec-eregs/issues/225.

## Screenshots
<img alt="screenshot from 2016-09-08 16-36-24" src="https://cloud.githubusercontent.com/assets/509703/18370518/76a1b178-75e2-11e6-99bf-1dc07fa8c6f7.png" width="300">

cc @jenniferthibault 

- [x] Depends on #499 