### PR TITLE
Misc style tweeks

### DIFF
--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -5,12 +5,8 @@
 }
 
 .post {
-  border-top: 1px solid $gray-light;
+  border-bottom: 1px solid $gray-light;
   padding: u(2rem 0);
-
-  &:last-of-type {
-    border-bottom: 1px solid $gray-light;
-  }
 
   h3 {
     margin-bottom: u(1rem);

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -47,7 +47,8 @@
   font-family: $sans-serif;
   letter-spacing: -.3px;
 
-  p, li {
+  p,
+  li {
     font-size: u(1.4rem);
   }
 }

--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -46,6 +46,10 @@
 .glossary__definition {
   font-family: $sans-serif;
   letter-spacing: -.3px;
+
+  p, li {
+    font-size: u(1.4rem);
+  }
 }
 
 .glossary__toggle {

--- a/scss/modules/_site-header.scss
+++ b/scss/modules/_site-header.scss
@@ -4,7 +4,6 @@
 
 // Staging banner
 .banner {
-  display: none;
   background-color: $navy;
   color: $inverse;
   font-family: $sans-serif;


### PR DESCRIPTION
## Summary
- Changes the border on the `.post` class to a bottom border:
![image](https://cloud.githubusercontent.com/assets/1696495/18457082/be2a2f22-790a-11e6-9c08-70682b3948c8.png)

- Sets a uniform font size on glossary content:
![image](https://cloud.githubusercontent.com/assets/1696495/18457064/99eb5e88-790a-11e6-81b1-c7c545d161cb.png)

- Displays the banner on dev and staging

Resolves https://github.com/18F/fec-style/issues/432
Resolves https://github.com/18F/fec-style/issues/489