### PR TITLE
Date Filter - mobile design

### DIFF
--- a/scss/components/_date-grid.scss
+++ b/scss/components/_date-grid.scss
@@ -36,13 +36,14 @@
 
 .date-range__year {
   line-height: u(3rem);
+  padding-right: u(1rem);
   float: left;
   clear: both;
 }
 
 .date-range__months {
-  width: 220px;
-  float: right;
+  width: 215px;
+  float: left;
 
   li {
     width: 35px;

--- a/scss/components/_form-styles.scss
+++ b/scss/components/_form-styles.scss
@@ -246,9 +246,7 @@
     background-position: right 50% top 50%;
     padding: u(1.25rem 1.5rem);
     margin-left: u(.25rem);
-    right: 0;
-    bottom: 0;
-    position: absolute;
+    vertical-align: bottom;
 
     &.is-loading {
       background-image: url('../img/loading-ellipsis-gray.gif');


### PR DESCRIPTION
Aligned the range buttons and date grid to prevent extra space showing on mobile/tablet screens:

<img width="415" alt="screen shot 2016-09-16 at 7 31 31 am" src="https://cloud.githubusercontent.com/assets/24054/18589487/db0a0f04-7bdf-11e6-8273-93800971e3db.png">

#502