### PR TITLE
Fix grid for multiple rows

### DIFF
--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -65,18 +65,15 @@
   }
 }
 
-// BREAKPOINT: MEDIUM
-@include media($med) {
+// BREAKPOINT: LARGE
+@include media($lg) {
   .grid--2-wide {
     .grid__item {
       @include span-columns(6);
       @include omega(2n);
     }
   }
-}
 
-// BREAKPOINT: LARGE
-@include media($lg) {
   .grid--3-wide {
     .grid__item {
       @include span-columns(4);

--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -20,12 +20,24 @@
 //   <div class="grid__item">
 //     Grid item
 //   </div>
+//   <div class="grid__item">
+//     Grid item
+//   </div>
+//   <div class="grid__item">
+//     Grid item
+//   </div>
+//   <div class="grid__item">
+//     Grid item
+//   </div>
+//   <div class="grid__item">
+//     Grid item
+//   </div>
 // </div>
 //
 // Styleguide layout.grids
 
 .grid {
-  @include clearfix();
+  @include outer-container;
 }
 
 .grid__item {
@@ -34,16 +46,17 @@
 }
 
 // BREAKPOINT: MEDIUM
-@include media($med) {
+// We set a max-width to prevent the omega mixins from applying multiple times.
+// This is based on $large-screen, but we have to convert to px so that we can
+// subtract a pixel. Otherwise, the breakpoints will overlap at 860px (the
+// large breakpoint).
+@include media(min-width $medium-screen max-width (strip-units($large-screen) * $em-base - 1)) {
   .grid--2-wide,
   .grid--3-wide,
   .grid--4-wide {
     .grid__item {
       @include span-columns(6);
-
-      &:nth-child(2) {
-        margin-right: 0;
-      }
+      @include omega(2n);
     }
   }
 
@@ -52,31 +65,29 @@
   }
 }
 
+// BREAKPOINT: MEDIUM
+@include media($med) {
+  .grid--2-wide {
+    .grid__item {
+      @include span-columns(6);
+      @include omega(2n);
+    }
+  }
+}
+
 // BREAKPOINT: LARGE
 @include media($lg) {
   .grid--3-wide {
     .grid__item {
       @include span-columns(4);
-      margin-bottom: 0;
-
-      &:nth-child(2) {
-        margin-right: flex-gutter();
-      }
-
-      &:nth-child(3) {
-        margin-right: 0;
-      }
+      @include omega(3n);
     }
   }
 
   .grid--4-wide {
     .grid__item {
       @include span-columns(3);
-      margin-bottom: 0;
-
-      &:nth-child(2) {
-        margin-right: flex-gutter();
-      }
+      @include omega(4n);
     }
   }
 }


### PR DESCRIPTION
## Summary

I was playing around with the grid, but it wasn't working as expected for 3 and 4 column grids. The main issue was that the `nth-child` margin rules were being applied multiple times, at different intervals because the breakpoints overlap. The issue is kind of hidden from the styleguide because we're not including enough grid items.

To fix this, I introduced a one-off media query that has a `max-width` to prevent the breakpoint overlap. This is an exception to how we usually define breakpoints, but I think the implementation is reasonable (at least we're using the `$large-screen` variable).

## Screenshots

### Before

#### 2-wide
![screenshot from 2016-09-16 10-36-45](https://cloud.githubusercontent.com/assets/509703/18595466/bb89885c-7bf9-11e6-958b-f2ffe6ea4b8a.png)

#### 3-wide
![screenshot from 2016-09-16 10-36-56](https://cloud.githubusercontent.com/assets/509703/18595474/c16d8430-7bf9-11e6-8adf-aa1539532b4d.png)

#### 4-wide
![screenshot from 2016-09-16 10-37-06](https://cloud.githubusercontent.com/assets/509703/18595483/c931b2e0-7bf9-11e6-8393-6f8b523b48a4.png)

### After

#### 2-wide
![screenshot from 2016-09-16 10-38-02](https://cloud.githubusercontent.com/assets/509703/18595509/eb6f77c0-7bf9-11e6-8766-90cfdfdbf81f.png)

#### 3-wide
![screenshot from 2016-09-16 10-38-09](https://cloud.githubusercontent.com/assets/509703/18595520/f642cfee-7bf9-11e6-82c9-816bb05bd530.png)

#### 4-wide
![screenshot from 2016-09-16 10-38-21](https://cloud.githubusercontent.com/assets/509703/18595530/ff081990-7bf9-11e6-9dd5-9df9470ce596.png)

cc @noahmanger 

