### PR TITLE
Cleaning up styles on lists and tables on custom pages

### DIFF
--- a/scss/components/_list-styles.scss
+++ b/scss/components/_list-styles.scss
@@ -2,10 +2,11 @@
 //
 // These are classes to be applied to lists to give them particular styles
 //
-// .list--bulleted  - Bulleted list (for ul)
-// .list--numbered  - Numbered list (for ol)
-// .list--flat      - Lay out items horizontally
-// .list--spacious  - Adds padding above and below list items
+// .list--bulleted      - Bulleted list (for ul)
+// .list--bulleted--alt - Bulleted list where child lists don't have bullets
+// .list--numbered      - Numbered list (for ol)
+// .list--flat          - Lay out items horizontally
+// .list--spacious      - Adds padding above and below list items
 //
 // Markup:
 // <ul class="{{modifier_class}}">
@@ -17,9 +18,9 @@
 // Styleguide components.list-styles
 
 .list--numbered,
-.list--bulleted {
+.list--bulleted,
+.list--bulleted--alt {
   li {
-    list-style-type: disc;
     margin-left: u(2rem);
     padding: u(.5rem 0);
     font-size: u(1.6rem);
@@ -33,6 +34,16 @@
 .list--bulleted {
   li {
     list-style-type: disc;
+  }
+}
+
+.list--bulleted--alt {
+  & > li {
+    list-style-type: disc;
+  }
+
+  ul li {
+    list-style-type: none;
   }
 }
 

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -30,3 +30,29 @@
     }
   }
 }
+
+// Special press release styling
+// .press_release_content is an inheritied class from the scraped content
+// A lot of the scraped content contains tables or other weird things
+// So this allows us to target just that
+
+.body-blocks .press_release_content {
+  table {
+    border-width: 0;
+    font-family: $serif;
+    color: $base;
+  }
+
+  tr {
+    border: none;
+  }
+
+  td {
+    padding: 0;
+  }
+
+  ul {
+    @extend .list--bulleted;
+  }
+
+}

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -2,28 +2,30 @@
 //
 // These are styles specifically for content output by the CMS
 
-.rich-text {
- ul:not(.list--checks) {
-  li {
-    font-size: u(1.6rem);
-  }
-
+.rich-text,
+.body-blocks {
   ul {
-    margin-bottom: u(1rem);
+    @extend .list--bulleted;
 
     li {
-      list-style-type: disc;
-      margin-left: u(2rem);
-      padding: u(0 0 .5rem 0);
-      margin-bottom: 0;
+      font-size: u(1.6rem);
+    }
 
-      // Hack because the editor is putting all text in <p>s
-      p {
+    ul {
+      margin-bottom: u(1rem);
+
+      li {
+        margin-left: u(2rem);
+        padding: u(0 0 .5rem 0);
         margin-bottom: 0;
+
+        // Hack because the editor is putting all text in <p>s
+        p {
+          margin-bottom: 0;
+        }
       }
     }
-  }
- }
+   }
 
   ol {
     li {
@@ -32,7 +34,10 @@
       padding-left: u(1rem);
     }
   }
+}
 
+.rich-text,
+.block-table {
   table {
     @extend .simple-table;
   }
@@ -51,7 +56,8 @@
 }
 
 @media print {
-  .rich-text table {
+  .rich-text table,
+  .block-table table {
     page-break-inside: avoid;
   }
 }

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -6,33 +6,10 @@
 .body-blocks {
   ul {
     @extend .list--bulleted;
-
-    li {
-      font-size: u(1.6rem);
-    }
-
-    ul {
-      margin-bottom: u(1rem);
-
-      li {
-        margin-left: u(2rem);
-        padding: u(0 0 .5rem 0);
-        margin-bottom: 0;
-
-        // Hack because the editor is putting all text in <p>s
-        p {
-          margin-bottom: 0;
-        }
-      }
-    }
    }
 
   ol {
-    li {
-      list-style-type: decimal;
-      margin: 0;
-      padding-left: u(1rem);
-    }
+    @extend .list--numbered;
   }
 }
 


### PR DESCRIPTION
## Summary
Makes several small changes to clean up / fix styling on custom pages, including the new press content pages.

## Screenshots
Creates a new class `.list--bulleted--alt` in which only the first level of `<li>` have bullets, and nested `<ul>` don't:
![image](https://cloud.githubusercontent.com/assets/1696495/18603873/3a6fb364-7c2a-11e6-9fed-42bec078a1b5.png)

Restores standard bulleted list and table styling to the custom pages:

![image](https://cloud.githubusercontent.com/assets/1696495/18603876/495769a8-7c2a-11e6-8430-6c3094d61bef.png)

Cleans up unnecessary extra styles from the `.rich-text` class by just using `@extend`

Adds some special styles to account for the fact that scraped press releases contain tables for layout.

Resolves https://github.com/18F/fec-cms/issues/494

cc @emileighoutlaw @adborden 
