### PR TITLE
[WIP] Styles for mobile side-nav

### DIFF
--- a/scss/components/_side-nav.scss
+++ b/scss/components/_side-nav.scss
@@ -17,7 +17,11 @@
 // Styleguide components.side-nav
 
 .side-nav {
-  display: none;
+  margin-bottom: 2rem; // For small screens
+
+  .is-stuck & {
+    display: none;
+  }
 }
 
 .side-nav__item {
@@ -60,6 +64,10 @@
 
 @include media($med) {
   .side-nav {
-    display: block;
+    margin-bottom: 0;
+
+    .is-stuck & {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
This is kind of an experiment for changing the mobile behavior of the `side-nav`. Before, we hide the `side-nav` on mobile. Now, we display it and just disable the sticky behavior using a `resize` listener.

![screenshot from 2016-09-16 17-20-51](https://cloud.githubusercontent.com/assets/509703/18604516/68bd4ee0-7c32-11e6-88e7-1cc7bad25efa.png)

cc @noahmanger 
