### PR TITLE
Simplify DateFilter for non two-year transaction periods

### DIFF
--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -25,11 +25,6 @@ function DateFilter(elm) {
     oncomplete: this.validate.bind(this)
   });
 
-  if (this.$minDate.attr('data-min-date')) {
-    this.$minDate.val(this.$minDate.data('min-date')).change();
-    this.$maxDate.val(this.$maxDate.data('max-date')).change();
-  }
-
   this.$input.on('change', this.handleInputChange.bind(this));
 
   this.fields = ['min_' + this.name, 'max_' + this.name];

--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -53,6 +53,7 @@ DateFilter.prototype.handleInputChange = function(e) {
   // tags should be removable
   if ($input.data('removable')) {
     nonremovable = false;
+    $input.data('loaded-once', true);
   }
 
   if ($input.data('had-value') && value.length > 0) {

--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -45,8 +45,15 @@ DateFilter.prototype.handleInputChange = function(e) {
   var value = $input.val();
   var loadedOnce = $input.data('loaded-once') || false;
   var range = $input.data('range') || false;
+  var nonremovable = true;
   var rangename = 'date';
   var eventName;
+
+  // on dates that aren't tied to two-year transactional periods
+  // tags should be removable
+  if ($input.data('removable')) {
+    nonremovable = false;
+  }
 
   if ($input.data('had-value') && value.length > 0) {
     eventName = 'filter:renamed';
@@ -72,7 +79,7 @@ DateFilter.prototype.handleInputChange = function(e) {
       range: range,
       rangeName: rangename,
       name: this.name,
-      nonremovable: true
+      nonremovable: nonremovable
     }
   ]);
 

--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -25,8 +25,13 @@ function DateFilter(elm) {
     oncomplete: this.validate.bind(this)
   });
 
+  if (this.$minDate.attr('data-min-date')) {
+    this.$minDate.val(this.$minDate.data('min-date')).change();
+    this.$maxDate.val(this.$maxDate.data('max-date')).change();
+  }
+
   this.$input.on('change', this.handleInputChange.bind(this));
-  this.$elm.on('change', this.handleRadioChange.bind(this));
+
   this.fields = ['min_' + this.name, 'max_' + this.name];
 
   this.$minDate.on('focus', this.handleMinDateSelect.bind(this));
@@ -39,16 +44,6 @@ function DateFilter(elm) {
 
 DateFilter.prototype = Object.create(Filter.Filter.prototype);
 DateFilter.constructor = DateFilter;
-
-// TODO: Remove once date filters no longer have radios
-DateFilter.prototype.handleRadioChange = function(e) {
-  var $input = $(e.target);
-  if (!$input.is(':checked')) { return; }
-  if ($input.attr('data-min-date')) {
-    this.$minDate.val($input.data('min-date')).change();
-    this.$maxDate.val($input.data('max-date')).change();
-  }
-};
 
 DateFilter.prototype.handleInputChange = function(e) {
   var $input = $(e.target);


### PR DESCRIPTION
Date filters that are not bound to two-year transaction periods will not have a radio selection but  simpler beginning/end input date fields. Relies on 18F/openfec-web-app#1590.

Issue: #501

<img width="278" alt="screen shot 2016-09-19 at 3 04 38 pm" src="https://cloud.githubusercontent.com/assets/24054/18650558/88332340-7e7a-11e6-8ea0-080390790ed0.png">
