### PR TITLE
Fix filter gutter on mobile

### DIFF
--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -104,6 +104,7 @@ $filter-button-width: u(4.6rem);
       &::after {
         @include u-icon-bg($x, $error);
         background-position: 50%;
+        right: u(-3rem);
       }
     }
   }

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -74,7 +74,6 @@ $filter-button-width: u(4.6rem);
       position: absolute;
       top: 0;
       bottom: 0;
-      right: u(-3rem);
     }
 
     &.is-loading {
@@ -84,6 +83,7 @@ $filter-button-width: u(4.6rem);
         @include animation(fadeIn .8s ease-out);
         background: url('../img/loading-ellipsis-gray.gif') no-repeat;
         background-size: u(2rem);
+        right: u(-3rem);
         opacity: 1;
       }
     }
@@ -94,6 +94,7 @@ $filter-button-width: u(4.6rem);
       &::after {
         @include u-icon-bg($check, $green-light);
         background-position: 50%;
+        right: u(-3rem);
       }
     }
 


### PR DESCRIPTION
Tweaked the default negative right margins on filter labels so it doesn't create a gutter on mobile screens. Issue #488 