### PR TITLE
Fix calendar filter counts

### DIFF
--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -140,3 +140,10 @@ Filter.prototype.enable = function() {
   });
   this.isEnabled = true;
 };
+
+module.exports = {
+  Filter: Filter,
+  ensureArray: ensureArray,
+  prepareValue: prepareValue
+};
+

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -18,6 +18,7 @@ function prepareValue($elm, value) {
 function Filter(elm) {
   this.$elm = $(elm);
   this.$input = this.$elm.find('input:not([name^="_"])');
+  this.$label = this.$elm.find('label').attr('for');
   this.$filterLabel = this.$elm.closest('.accordion__content').prev();
 
   // on error message, click to open feedback panel
@@ -26,6 +27,13 @@ function Filter(elm) {
   });
 
   this.name = this.$elm.data('name') || this.$input.attr('name');
+
+  // when there are multiple filters with the same name
+  // set the name to label to avoid inflated filter counts
+  if (this.$elm.hasClass('js-multi-filter')) {
+    this.name = this.$label;
+  }
+
   this.fields = [this.name];
   this.lastAction;
 
@@ -132,30 +140,3 @@ Filter.prototype.enable = function() {
   });
   this.isEnabled = true;
 };
-
-/* MultiFilters used when there are multiple filters that share the
- * same name attribute
-*/
-
-function MultiFilter(elm) {
-  Filter.call(this, elm);
-  this.$group = $(this.$elm.data('filter-group'));
-  this.$input = this.$group.find('input[name=' + this.name + ']');
-}
-
-MultiFilter.prototype = Object.create(Filter.prototype);
-MultiFilter.constructor = MultiFilter;
-
-// This is a temporary override for the calendar filters to not show filter count
-// Because this filter has multiple inputs with the same name,
-// the filter count gets updated for each one,
-// resulting in inflated numbers.
-MultiFilter.prototype.handleAddEvent = function() { return; };
-
-module.exports = {
-  Filter: Filter,
-  MultiFilter: MultiFilter,
-  ensureArray: ensureArray,
-  prepareValue: prepareValue
-};
-

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -6,7 +6,6 @@ var URI = require('urijs');
 
 var TextFilter = require('./text-filter').TextFilter;
 var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
-var MultiFilter = require('./filter-base').MultiFilter;
 var TypeaheadFilter = require('./typeahead-filter').TypeaheadFilter;
 var SelectFilter = require('./select-filter').SelectFilter;
 var DateFilter = require('./date-filter').DateFilter;
@@ -29,7 +28,6 @@ var filterMap = {
   'date': DateFilter,
   'typeahead': TypeaheadFilter,
   'election': ElectionFilter,
-  'multi': MultiFilter,
   'select': SelectFilter,
   'toggle': ToggleFilter,
   'range': RangeFilter,

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -95,6 +95,7 @@
     display: block;
     margin: 0;
     padding: u(.5rem 1rem);
+    max-width: 100%;
     white-space: nowrap;
 
     &:hover {

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -65,6 +65,7 @@ $filter-button-width: u(4.6rem);
 
   // Loading states
   label {
+    position: relative;
 
     &::after {
       background: transparent;
@@ -224,6 +225,7 @@ $filter-button-width: u(4.6rem);
   }
 
   label {
+    max-width: 90%;
     line-height: 1;
   }
 


### PR DESCRIPTION
The issue (#449) with inflated calendar filter counts is caused by multiple filters sharing the same name. This can be remedied simply by setting the `this.name` variable to the unique label instead, thus preventing inflated filter counts.

<img width="299" alt="screen shot 2016-09-22 at 12 58 35 pm" src="https://cloud.githubusercontent.com/assets/24054/18763957/52b5a976-80c4-11e6-9454-c25b920ba2cc.png"> <img width="300" alt="screen shot 2016-09-22 at 1 00 08 pm" src="https://cloud.githubusercontent.com/assets/24054/18764038/9e4b813a-80c4-11e6-8d30-ec7d8551047a.png">

cc @noahmanger 