### PR TITLE
Add styles for enforcement landing

### DIFF
--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -42,11 +42,6 @@ $search-button-width: u(5.6rem);
 
 .search__example {
   margin-top: u(1rem);
-
-  // For aligning the example text after a select input
-  &.search__example--with-select {
-    margin: u(1rem) 0 0 u(21rem);
-  }
 }
 
 .combo--search--inline {
@@ -132,6 +127,11 @@ $search-button-width: u(5.6rem);
     .tt-suggestion__header {
       display: none;
     }
+  }
+
+  // For aligning the example text after a select input
+  .search__example--with-select {
+    margin: u(1rem) 0 0 u(21rem);
   }
 }
 

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -42,6 +42,17 @@ $search-button-width: u(5.6rem);
 
 .search__example {
   margin-top: u(1rem);
+
+  // For aligning the example text after a select input
+  &.search__example--with-select {
+    margin: u(1rem) 0 0 u(21rem);
+  }
+}
+
+.combo--search--inline {
+  .combo__input {
+    border-radius: 4px 0 0 4px;
+  }
 }
 
 .combo--search--mini {
@@ -89,10 +100,6 @@ $search-button-width: u(5.6rem);
     .tt-menu {
       width: calc(100% - 6.8rem);
     }
-  }
-
-  .search__example {
-    margin: u(1rem) 0 0 u(21rem);
   }
 
   .combo--search--large {

--- a/scss/layout/_slabs.scss
+++ b/scss/layout/_slabs.scss
@@ -43,6 +43,17 @@
   padding: u(4rem 0);
 }
 
+.slab--inline {
+  border-radius: 4px;
+}
+
+@include media($lg) {
+  .slab--inline .container {
+    padding-left: u(2rem);
+    padding-right: u(2rem);
+  }
+}
+
 // Reset all slab colors on print
 @media print {
   .slab,

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -387,11 +387,14 @@
 // Printer style utitlity
 .u-print-only {
   display: none;
-}
 
-@media print {
-  .u-print-only {
+  @media print {
     display: block;
   }
 }
 
+.u-no-print {
+  @media print {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Includes styles for the enforcement matters landing page. Introduces a `.slab--inline` for non-full-width slabs, like the MURs search. Also creates a `.u-no-print` utility to hide elements for print.

## Screenshots

![screenshot from 2016-09-26 19-27-45](https://cloud.githubusercontent.com/assets/509703/18858240/58d66224-841f-11e6-9c18-404a3da24c81.png)


cc @jenniferthibault @noahmanger 

