### PR TITLE
Changing font size

### DIFF
--- a/scss/components/_charts.scss
+++ b/scss/components/_charts.scss
@@ -430,7 +430,7 @@ $tooltip-border-color: #999;
   h5 {
     display: inline-block;
     font-family: $sans-serif;
-    font-size: u(1.4rem);
+    font-size: u(1.3rem);
     font-weight: bold;
     padding: u(.8rem 0);
     margin: 0;


### PR DESCRIPTION
Bumps the font-size down of the snapshot controls for the data landing page charts.

This is a somewhat hacky solution to prevent awkward breaking of the component at certain window widths. 

I'm going to keep https://github.com/18F/fec-style/issues/525 open as an issue to come up with a more resilient, less brittle solution in the future.

cc @jenniferthibault 
