### PR TITLE
Moves the typeahead init code to init

### DIFF
--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -120,10 +120,6 @@ function Typeahead(selector, type, url) {
 
   this.init(type || 'candidates');
 
-  this.$element = this.$input.parent('.twitter-typeahead');
-  this.$element.css('display', 'block');
-  this.$element.find('.tt-menu').attr('aria-live', 'polite');
-
   events.on('searchTypeChanged', this.handleChangeEvent.bind(this));
 }
 
@@ -133,6 +129,9 @@ Typeahead.prototype.init = function(type) {
   }
   this.dataset = datasets[type];
   this.typeahead = this.$input.typeahead(typeaheadOpts, this.dataset);
+  this.$element = this.$input.parent('.twitter-typeahead');
+  this.$element.css('display', 'block');
+  this.$element.find('.tt-menu').attr('aria-live', 'polite');
   this.$input.on('typeahead:select', this.select.bind(this));
 };
 


### PR DESCRIPTION
Fixes an issue where the `.tt-typeahead` div didn’t get `display:block` set on changing the input type, which broke the layout.

Resolves https://github.com/18F/openFEC-web-app/issues/1606

cc @xtine 