### PR TITLE
Enable support for custom tag values in data attributes

### DIFF
--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -20,12 +20,13 @@ ToggleFilter.prototype.fromQuery = function(query) {
 };
 
 ToggleFilter.prototype.handleChange = function(e) {
+  var $input = $(e.target);
   var value = $(e.target).data('tag-value');
   var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';
   this.$elm.trigger(eventName, [
     {
       key: this.name + '-toggle',
-      value: value,
+      value: this.formatValue($input, value),
       loadedOnce: this.loadedOnce || false,
       name: this.name,
       nonremovable: true

--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -20,12 +20,12 @@ ToggleFilter.prototype.fromQuery = function(query) {
 };
 
 ToggleFilter.prototype.handleChange = function(e) {
-  var value = $(e.target).val();
+  var value = $(e.target).data('tag-value');
   var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';
   this.$elm.trigger(eventName, [
     {
       key: this.name + '-toggle',
-      value: 'Data type: ' + value,
+      value: value,
       loadedOnce: this.loadedOnce || false,
       name: this.name,
       nonremovable: true

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -14,11 +14,11 @@ var ToggleFilter = require('../js/toggle-filter').ToggleFilter;
 var DOM = '<fieldset class="js-filter">' +
             '<legend class="label">Data type</legend>' +
             '<label for="processed">' +
-              '<input type="radio" value="processed" id="processed" checked name="data_type" data-tag-value="Data type: processed">' +
+              '<input type="radio" value="processed" id="processed" checked name="data_type" data-prefix="Data type:" data-tag-value="processed">' +
               '<span>Processed data</span>' +
             '</label>' +
             '<label for="efiling">' +
-              '<input type="radio" value="efiling" id="efiling" name="data_type" data-tag-value="Data type: efiling">' +
+              '<input type="radio" value="efiling" id="efiling" name="data_type" data-prefix="Data type:" data-tag-value="efiling">' +
               '<span>eFilings</span>' +
             '</label>' +
           '</fieldset>';
@@ -84,7 +84,7 @@ describe('checkbox filters', function() {
       expect(this.trigger).to.have.been.calledWith('filter:added', [
         {
           key: 'data_type-toggle',
-          value: 'Data type: processed',
+          value: '<span class="prefix">Data type: </span>processed',
           loadedOnce: false,
           name: 'data_type',
           nonremovable: true
@@ -97,7 +97,7 @@ describe('checkbox filters', function() {
       expect(this.trigger).to.have.been.calledWith('filter:renamed', [
         {
           key: 'data_type-toggle',
-          value: 'Data type: efiling',
+          value: '<span class="prefix">Data type: </span>efiling',
           loadedOnce: true,
           name: 'data_type',
           nonremovable: true

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -14,11 +14,11 @@ var ToggleFilter = require('../js/toggle-filter').ToggleFilter;
 var DOM = '<fieldset class="js-filter">' +
             '<legend class="label">Data type</legend>' +
             '<label for="processed">' +
-              '<input type="radio" value="processed" id="processed" checked name="data_type">' +
+              '<input type="radio" value="processed" id="processed" checked name="data_type" data-tag-value="Data type: processed">' +
               '<span>Processed data</span>' +
             '</label>' +
             '<label for="efiling">' +
-              '<input type="radio" value="efiling" id="efiling" name="data_type">' +
+              '<input type="radio" value="efiling" id="efiling" name="data_type" data-tag-value="Data type: efiling">' +
               '<span>eFilings</span>' +
             '</label>' +
           '</fieldset>';


### PR DESCRIPTION
This enables passing custom tag values in `ToggleFilter` filters, which is useful in the case of when a filter is simply a boolean. A tag that just says `true` or `false` isn't much use, so this allows you to set a `data-tag-value` on the input and that will be used as the value for the tag. 

Goes with https://github.com/18F/openFEC-web-app/pull/1565