### PR TITLE
Alert consistency

### DIFF
--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -287,7 +287,7 @@ DateFilter.prototype.showWarning = function() {
   if (!this.showingWarning) {
     var warning =
     '<div class="message message--error message--small">' +
-      'You entered a date that\'s outside the selected transaction period. ' +
+      'You entered a date that\'s outside the two-year time period. ' +
       'Please enter a receipt date from ' +
       '<strong>' + this.minYear + '-' + this.maxYear + '</strong>' +
     '</div>';


### PR DESCRIPTION
On our receipts page, the alert message for selecting a date that falls outside the two-year period currently says

"You entered a date that's outside the selected transaction period." But there's no _thing_ on the page called "transaction period," which is confusing.  

Screenshot:
<img width="264" alt="screen shot 2016-10-04 at 4 03 53 pm" src="https://cloud.githubusercontent.com/assets/10552702/19092692/69942a90-8a4d-11e6-9345-b926098af427.png">


This PR is to make the language more consistent with the filters we already have applied. 

cc @jenniferthibault @noahmanger @xtine 
