### PR TITLE
prevent focus from firing change event twice

### DIFF
--- a/js/text-filter.js
+++ b/js/text-filter.js
@@ -42,7 +42,7 @@ TextFilter.prototype.handleChange = function() {
   var loadedOnce = this.$input.data('loaded-once') || false;
   var button = this.$submit;
 
-  // wrap the button focus with a 0 timeout
+  // set the button focus within a timeout
   // to prevent change event from firing twice
   setTimeout(function() {
     button.focus();

--- a/js/text-filter.js
+++ b/js/text-filter.js
@@ -40,9 +40,14 @@ TextFilter.prototype.fromQuery = function(query) {
 TextFilter.prototype.handleChange = function() {
   var value = this.$input.val();
   var loadedOnce = this.$input.data('loaded-once') || false;
+  var button = this.$submit;
 
-  // set focus to button
-  this.$submit.focus();
+  // wrap the button focus with a 0 timeout
+  // to prevent change event from firing twice
+  setTimeout(function() {
+    button.focus();
+  }, 0);
+
   if (value.length > 0) {
     this.$submit.removeClass('is-disabled');
     this.appendCheckbox(value);


### PR DESCRIPTION
Currently pressing enter on text inputs causes the change event to fire twice, causing duplicate checkboxes to show up in the search filter. This fix wraps the button focus in a timeout, preventing a second change event from happening.

18F/fec#490