### PR TITLE
Replacing hard-coded value with the filter's name

### DIFF
--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -16,7 +16,7 @@ ToggleFilter.prototype = Object.create(Filter.prototype);
 ToggleFilter.constructor = ToggleFilter;
 
 ToggleFilter.prototype.fromQuery = function(query) {
-  this.$elm.find('input[value="' + query.data_type + '"]').prop('checked', true).change();
+  this.$elm.find('input[value="' + query[this.name] + '"]').prop('checked', true).change();
 };
 
 ToggleFilter.prototype.handleChange = function(e) {


### PR DESCRIPTION
This resolves a bug where when visiting a page like https://beta.fec.gov/data/independent-expenditures/?is_notice=true where `is_notice=true` was set, and the filter wouldn't set it's value from the query correctly.

This patch simply fixes the way that the filter looks up the active element by replacing the hard-coded value `query.data_type` with `query[this.name]` so that it works for filters with `name` values other than `data_type`. 

Resolves https://github.com/18F/openFEC-web-app/issues/1634