### PR TITLE
Making footer links sans serif

### DIFF
--- a/scss/modules/_footer.scss
+++ b/scss/modules/_footer.scss
@@ -20,6 +20,7 @@
 .footer-links {
   background-color: $navy;
   color: $inverse;
+  font-family: $sans-serif;
   padding: u(1rem 0);
 
   a {


### PR DESCRIPTION
This makes the footer links sans-serif. 

![image](https://cloud.githubusercontent.com/assets/1696495/19541479/76932726-961b-11e6-975f-1873160a6b3b.png)

cc @jenniferthibault 

Resolves https://github.com/18F/fec-style/issues/539