### PR TITLE
Adding definition for other group

### DIFF
--- a/js/terms.json
+++ b/js/terms.json
@@ -113,7 +113,7 @@
     "definition": "An organization, agency or employee representative committee or plan, in which employees participate and which exists for the purpose of dealing with employers on grievances, labor disputes, wages, hours of employment or working conditions. 114.1(d)."
   },
   {
-    "term": "Other groups",
+    "term": "Communications filers",
     "definition": "Form 5, Form 7 and Form 9 filers, whose activity includes: <ul class='list--bulleted'><li>Contributions reported by persons other than political committees</li><li>Independent expenditures reported by persons other than political committees</li><li>Communication costs reported by corporations and membership organizations</li><li>Electioneering communications</li></ul>"
   },
   {

--- a/js/terms.json
+++ b/js/terms.json
@@ -113,6 +113,10 @@
     "definition": "An organization, agency or employee representative committee or plan, in which employees participate and which exists for the purpose of dealing with employers on grievances, labor disputes, wages, hours of employment or working conditions. 114.1(d)."
   },
   {
+    "term": "Other groups",
+    "definition": "Form 5, Form 7 and Form 9 filers, whose activity includes: <ul class='list--bulleted'><li>Contributions reported by persons other than political committees</li><li>Independent expenditures reported by persons other than political committees</li><li>Communication costs reported by corporations and membership organizations</li><li>Electioneering communications</li></ul>"
+  },
+  {
     "term": "Person",
     "definition": "An individual, partnership, political committee, corporation, labor organization or any other organization or group of persons, not including the federal government. 100.10."
   },


### PR DESCRIPTION
Adds a glossary term for "Other groups" with this definition:

```
Form 5, Form 7 and Form 9 filers, whose activity includes: 
- Contributions reported by persons other than political committees
- Independent expenditures reported by persons other than political committees
- Communication costs reported by corporations and membership organizations
- Electioneering communications
```

cc @emileighoutlaw @amykort