### PR TITLE
Eliminates view

### DIFF
--- a/fec-template/templates/toggles.hbs
+++ b/fec-template/templates/toggles.hbs
@@ -3,14 +3,14 @@
     {{#if (eq className 'button--alt-primary')}}slab--primary{{/if}}
     {{#if (eq className 'button--alt-secondary')}}slab--secondary{{/if}}" style="padding: 2rem">
     <fieldset class="toggles">
-      <legend class="label">View by:</legend>
+      <legend class="label">Show by:</legend>
       <label for="toggle-state-{{ index }}">
         <input id="toggle-state-{{ index }}" type="radio" name="receipt-aggregate--{{ index }}" value="by-state" checked>
         <span class="{{ className }}">State</span>
       </label>
       <label for="toggle-contribution-size-{{ index }}">
         <input id="toggle-contribution-size-{{ index }}" type="radio" name="receipt-aggregate--{{ index }}" value="by-contribution-size">
-        <span class="{{ className }}">Contribution Size</span>
+        <span class="{{ className }}">Contribution size</span>
       </label>
       <label for="toggle-employer-{{ index }}">
         <input id="toggle-employer-{{ index }}" type="radio" name="receipt-aggregate--{{ index }}" value="by-employer">

--- a/scss/modules/_datatable-panel.scss
+++ b/scss/modules/_datatable-panel.scss
@@ -134,7 +134,7 @@
   padding-left: u(3rem);
 
   &::after {
-    content: "View all";
+    content: "Show all";
   }
 }
 


### PR DESCRIPTION
"View" generally isn't an ideal word for interface copy, because it can feel exclusionary to folks who use screenreaders and aren't "viewing" the text. 

This changes "view" to "show" 
