### PR TITLE
Press boilerplate

### DIFF
--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -78,7 +78,7 @@
 // For earlier press releases, this isn't a separate div
 
 .post__boilerplate {
-  padding-top: u(2rem);
+  padding-top: u(1rem);
   font-style: italic;
 
   p {

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -71,3 +71,17 @@
   }
 
 }
+
+// Post boilerplate
+// The .post__boilerplate div is the blurb about the FEC
+// on press releases. This is hidden on 2016 and newer releases on screen, but is visible when printed.
+// For earlier press releases, this isn't a separate div
+
+.post__boilerplate {
+  padding-top: u(2rem);
+  font-style: italic;
+
+  p {
+    font-size: u(1.4rem);
+  }
+}


### PR DESCRIPTION
This adds specific styles for the boilerplate paragraph at the end of press releases. For new press releases, this will only be visible when printing, when it will look like this:

![image](https://cloud.githubusercontent.com/assets/1696495/20045139/8094be9c-a453-11e6-9f6f-28e52918b0d0.png)

For pre-2016 press releases, this paragraph isn't styled any differently and will remain in the web view, as it's just part of the content area.