### PR TITLE
Electronic filings

### DIFF
--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -153,7 +153,7 @@ TagList.prototype.renameTag = function(e, opts) {
 TagList.prototype.disableTag = function(e, opts) {
   var $tag = this.$list.find('[data-id="' + opts.key + '"]');
   $tag.addClass('is-disabled');
-  $tag.attr('title', 'This filter is not avaible for efiling data');
+  $tag.attr('title', 'This filter is not available for electronic filings data');
 };
 
 TagList.prototype.enableTag = function(e, opts) {

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -18,8 +18,8 @@ var DOM = '<fieldset class="js-filter">' +
               '<span>Processed data</span>' +
             '</label>' +
             '<label for="efiling">' +
-              '<input type="radio" value="efiling" id="efiling" name="data_type" data-prefix="Data type:" data-tag-value="efiling">' +
-              '<span>eFilings</span>' +
+              '<input type="radio" value="efiling" id="efiling" name="data_type" data-prefix="Data type:" data-tag-value="electronic filings">' +
+              '<span>Electronic filings</span>' +
             '</label>' +
           '</fieldset>';
 
@@ -97,7 +97,7 @@ describe('checkbox filters', function() {
       expect(this.trigger).to.have.been.calledWith('filter:renamed', [
         {
           key: 'data_type-toggle',
-          value: '<span class="prefix">Data type: </span>efiling',
+          value: '<span class="prefix">Data type: </span>electronic filings',
           loadedOnce: true,
           name: 'data_type',
           nonremovable: true


### PR DESCRIPTION
One of our UI consistency decisions was to use the phrase "electronic filings" rather than the more jargon-y "e-file" or "eFile" whenever possible.

This PR messes around with filters that have lots o' JS, so I'd like @noahmanger or @xtine to take a peek probably 


partially resolves: https://github.com/18F/fec-cms/issues/585