### PR TITLE
Making search example white

### DIFF
--- a/scss/modules/_glossary.scss
+++ b/scss/modules/_glossary.scss
@@ -6,6 +6,7 @@
   @include transition(right, .3s);
   background-color: $base;
   bottom: 0;
+  color: $inverse;
   max-width: u(30rem);
   overflow-y: scroll;
   padding: u(8rem 3rem);


### PR DESCRIPTION
This makes it so that the example text below the glossary search is white:

![image](https://cloud.githubusercontent.com/assets/1696495/20573167/698286c2-b163-11e6-8a57-739eaa77cdc7.png)
