### PR TITLE
Set width of filters__title

### DIFF
--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -34,6 +34,8 @@ $filter-button-width: u(4.6rem);
       left: 0;
     }
 
+    // For long filter titles, wrap them in a class to force icons to line up
+    // 7rem = width of filter icon + arrow icon + margin
     .filters__title {
       display: inline-block;
       width: calc(100% - 7rem)

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -34,6 +34,11 @@ $filter-button-width: u(4.6rem);
       left: 0;
     }
 
+    .filters__title {
+      display: inline-block;
+      width: calc(100% - 7rem)
+    }
+
     .filters__header {
       &::after {
         @include u-icon($arrow-left-border, $primary, $icon-size, $icon-size);

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -38,7 +38,7 @@ $filter-button-width: u(4.6rem);
     // 7rem = width of filter icon + arrow icon + margin
     .filters__title {
       display: inline-block;
-      width: calc(100% - 7rem)
+      width: calc(100% - 7rem);
     }
 
     .filters__header {


### PR DESCRIPTION
Ensures that the filters icon, arrow and title all line up neatly, like:

![image](https://cloud.githubusercontent.com/assets/1696495/20681392/4e441f26-b558-11e6-9d12-0e36be1ae23f.png)

https://github.com/18F/openFEC-web-app/pull/1711

cc @jenniferthibault @xtine 