### PR TITLE
Adjusting size and positioning of inline icons

### DIFF
--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -22,11 +22,11 @@
 .icon--inline--right {
   display: inline-block;
   margin-left: u(1rem);
-  vertical-align: middle;
+  vertical-align: text-bottom;
 }
 
 .icon--inline--left {
   display: inline-block;
   margin-right: u(1rem);
-  vertical-align: middle;
+  vertical-align: text-bottom;
 }

--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -8,6 +8,7 @@
 // .icon--inline--left    - Vertically centering and adding slight margin to inline icons
 
 .icon {
+  background-size: 100%;
   display: block;
   height: u(2rem);
   width: u(2rem);
@@ -19,11 +20,13 @@
 }
 
 .icon--inline--right {
+  display: inline-block;
   margin-left: u(1rem);
   vertical-align: middle;
 }
 
 .icon--inline--left {
+  display: inline-block;
   margin-right: u(1rem);
   vertical-align: middle;
 }


### PR DESCRIPTION
This makes a couple necessary adjustment in order to display inline icons as in this instance:
![image](https://cloud.githubusercontent.com/assets/1696495/20689515/a9aad798-b57a-11e6-9950-39195be0b0eb.png)

1. The `.icon` class now adjusts the background image to be 100% of the element
2. The `.icon--inline--*` classes are `display: inline-block`

Goes with https://github.com/18F/openFEC-web-app/pull/1707