### PR TITLE
Fix calendar filters

### DIFF
--- a/js/checkbox-filter.js
+++ b/js/checkbox-filter.js
@@ -43,6 +43,7 @@ CheckboxFilter.prototype.handleChange = function(e) {
       key: id,
       value: this.formatValue($input, $label.text()),
       loadedOnce: loadedOnce,
+      filterLabel: this.$filterLabel,
       name: this.name
     }
   ]);

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -29,10 +29,6 @@ function Filter(elm) {
   this.fields = [this.name];
   this.lastAction;
 
-  $(document.body).on('filter:added', this.handleAddEvent.bind(this));
-  $(document.body).on('filter:removed', this.handleRemoveEvent.bind(this));
-  $(document.body).on('filter:changed', this.setLastAction.bind(this));
-
   if (this.$elm.hasClass('js-filter-control')) {
     new FilterControl(this.$elm);
   }
@@ -40,6 +36,12 @@ function Filter(elm) {
   // For filters that are part of a MultiFilter, set a property
   if (this.$elm.hasClass('js-sub-filter')) {
     this.isSubfilter = true;
+  }
+
+  if (!this.isSubfilter) {
+    $(document.body).on('filter:added', this.handleAddEvent.bind(this));
+    $(document.body).on('filter:removed', this.handleRemoveEvent.bind(this));
+    $(document.body).on('filter:changed', this.setLastAction.bind(this));
   }
 }
 
@@ -72,39 +74,29 @@ Filter.prototype.formatValue = function($input, value) {
 
 Filter.prototype.handleAddEvent = function(e, opts) {
   if (opts.name !== this.name) { return; }
-  this.increment();
+  var $filterLabel = opts.filterLabel || this.$filterLabel;
+  var filterCount = $filterLabel.find('.filter-count');
+  if (filterCount.html()) {
+    filterCount.html(parseInt(filterCount.html(), 10) + 1);
+  }
+  else {
+    $filterLabel.append(' <span class="filter-count">1</span>');
+  }
   this.setLastAction(e, opts);
 };
 
 Filter.prototype.handleRemoveEvent = function(e, opts) {
   // Don't decrement on initial page load
   if (opts.name !== this.name || opts.loadedOnce !== true) { return; }
-  this.decrement();
-  this.setLastAction(e, opts);
-};
-
-Filter.prototype.increment = function() {
-  if (!this.isSubfilter) {
-    var filterCount = this.$filterLabel.find('.filter-count');
-
-    if (filterCount.html()) {
-      filterCount.html(parseInt(filterCount.html(), 10) + 1);
-    }
-    else {
-      this.$filterLabel.append(' <span class="filter-count">1</span>');
-    }
-  }
-};
-
-Filter.prototype.decrement = function() {
-  var filterCount = this.$filterLabel.find('.filter-count');
-
+  var $filterLabel = opts.filterLabel || this.$filterLabel;
+  var filterCount = $filterLabel.find('.filter-count');
   if (filterCount.html() === '1') {
     filterCount.remove();
   }
   else {
     filterCount.html(parseInt(filterCount.html(), 10) - 1);
   }
+  this.setLastAction(e, opts);
 };
 
 Filter.prototype.setLastAction = function(e, opts) {

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -18,7 +18,6 @@ function prepareValue($elm, value) {
 function Filter(elm) {
   this.$elm = $(elm);
   this.$input = this.$elm.find('input:not([name^="_"])');
-  this.$label = this.$elm.find('label').attr('for');
   this.$filterLabel = this.$elm.closest('.accordion__content').prev();
 
   // on error message, click to open feedback panel
@@ -27,13 +26,6 @@ function Filter(elm) {
   });
 
   this.name = this.$elm.data('name') || this.$input.attr('name');
-
-  // when there are multiple filters with the same name
-  // set the name to label to avoid inflated filter counts
-  if (this.$elm.hasClass('js-multi-filter')) {
-    this.name = this.$label;
-  }
-
   this.fields = [this.name];
   this.lastAction;
 
@@ -141,8 +133,28 @@ Filter.prototype.enable = function() {
   this.isEnabled = true;
 };
 
+/* MultiFilters used when there are multiple filters that share the
+ * same name attribute
+*/
+
+function MultiFilter(elm) {
+  Filter.call(this, elm);
+  this.$group = $(this.$elm.data('filter-group'));
+  this.$input = this.$group.find('input[name=' + this.name + ']');
+}
+
+MultiFilter.prototype = Object.create(Filter.prototype);
+MultiFilter.constructor = MultiFilter;
+
+// This is a temporary override for the calendar filters to not show filter count
+// Because this filter has multiple inputs with the same name,
+// the filter count gets updated for each one,
+// resulting in inflated numbers.
+MultiFilter.prototype.handleAddEvent = function() { return; };
+
 module.exports = {
   Filter: Filter,
+  MultiFilter: MultiFilter,
   ensureArray: ensureArray,
   prepareValue: prepareValue
 };

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -36,6 +36,11 @@ function Filter(elm) {
   if (this.$elm.hasClass('js-filter-control')) {
     new FilterControl(this.$elm);
   }
+
+  // For filters that are part of a MultiFilter, set a property
+  if (this.$elm.hasClass('js-sub-filter')) {
+    this.isSubfilter = true;
+  }
 }
 
 Filter.prototype.fromQuery = function(query) {
@@ -67,23 +72,31 @@ Filter.prototype.formatValue = function($input, value) {
 
 Filter.prototype.handleAddEvent = function(e, opts) {
   if (opts.name !== this.name) { return; }
-
-  var filterCount = this.$filterLabel.find('.filter-count');
-
-  if (filterCount.html()) {
-    filterCount.html(parseInt(filterCount.html(), 10) + 1);
-  }
-  else {
-    this.$filterLabel.append(' <span class="filter-count">1</span>');
-  }
-
+  this.increment();
   this.setLastAction(e, opts);
 };
 
 Filter.prototype.handleRemoveEvent = function(e, opts) {
   // Don't decrement on initial page load
   if (opts.name !== this.name || opts.loadedOnce !== true) { return; }
+  this.decrement();
+  this.setLastAction(e, opts);
+};
 
+Filter.prototype.increment = function() {
+  if (!this.isSubfilter) {
+    var filterCount = this.$filterLabel.find('.filter-count');
+
+    if (filterCount.html()) {
+      filterCount.html(parseInt(filterCount.html(), 10) + 1);
+    }
+    else {
+      this.$filterLabel.append(' <span class="filter-count">1</span>');
+    }
+  }
+};
+
+Filter.prototype.decrement = function() {
   var filterCount = this.$filterLabel.find('.filter-count');
 
   if (filterCount.html() === '1') {
@@ -92,8 +105,6 @@ Filter.prototype.handleRemoveEvent = function(e, opts) {
   else {
     filterCount.html(parseInt(filterCount.html(), 10) - 1);
   }
-
-  this.setLastAction(e, opts);
 };
 
 Filter.prototype.setLastAction = function(e, opts) {

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -80,13 +80,7 @@ Filter.prototype.handleAddEvent = function(e, opts) {
   // Subfilters don't add listeners that trigger this handler, so it will only
   // be called by the MultiFilter.
   var $filterLabel = opts.filterLabel || this.$filterLabel;
-  var filterCount = $filterLabel.find('.filter-count');
-  if (filterCount.html()) {
-    filterCount.html(parseInt(filterCount.html(), 10) + 1);
-  }
-  else {
-    $filterLabel.append(' <span class="filter-count">1</span>');
-  }
+  this.increment($filterLabel);
   this.setLastAction(e, opts);
 };
 
@@ -94,6 +88,21 @@ Filter.prototype.handleRemoveEvent = function(e, opts) {
   // Don't decrement on initial page load
   if (opts.name !== this.name || opts.loadedOnce !== true) { return; }
   var $filterLabel = opts.filterLabel || this.$filterLabel;
+  this.decrement($filterLabel);
+  this.setLastAction(e, opts);
+};
+
+Filter.prototype.increment = function($filterLabel) {
+  var filterCount = $filterLabel.find('.filter-count');
+  if (filterCount.html()) {
+    filterCount.html(parseInt(filterCount.html(), 10) + 1);
+  }
+  else {
+    $filterLabel.append(' <span class="filter-count">1</span>');
+  }
+};
+
+Filter.prototype.decrement = function($filterLabel) {
   var filterCount = $filterLabel.find('.filter-count');
   if (filterCount.html() === '1') {
     filterCount.remove();
@@ -101,7 +110,6 @@ Filter.prototype.handleRemoveEvent = function(e, opts) {
   else {
     filterCount.html(parseInt(filterCount.html(), 10) - 1);
   }
-  this.setLastAction(e, opts);
 };
 
 Filter.prototype.setLastAction = function(e, opts) {

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -133,28 +133,8 @@ Filter.prototype.enable = function() {
   this.isEnabled = true;
 };
 
-/* MultiFilters used when there are multiple filters that share the
- * same name attribute
-*/
-
-function MultiFilter(elm) {
-  Filter.call(this, elm);
-  this.$group = $(this.$elm.data('filter-group'));
-  this.$input = this.$group.find('input[name=' + this.name + ']');
-}
-
-MultiFilter.prototype = Object.create(Filter.prototype);
-MultiFilter.constructor = MultiFilter;
-
-// This is a temporary override for the calendar filters to not show filter count
-// Because this filter has multiple inputs with the same name,
-// the filter count gets updated for each one,
-// resulting in inflated numbers.
-MultiFilter.prototype.handleAddEvent = function() { return; };
-
 module.exports = {
   Filter: Filter,
-  MultiFilter: MultiFilter,
   ensureArray: ensureArray,
   prepareValue: prepareValue
 };

--- a/js/filter-base.js
+++ b/js/filter-base.js
@@ -19,7 +19,6 @@ function Filter(elm) {
   this.$elm = $(elm);
   this.$input = this.$elm.find('input:not([name^="_"])');
   this.$filterLabel = this.$elm.closest('.accordion__content').prev();
-
   // on error message, click to open feedback panel
   this.$elm.on('click', '.js-filter-feedback', function () {
     $(document.body).trigger('feedback:open');
@@ -74,6 +73,12 @@ Filter.prototype.formatValue = function($input, value) {
 
 Filter.prototype.handleAddEvent = function(e, opts) {
   if (opts.name !== this.name) { return; }
+  // The only time when opts.filterLabel != this.$filterLabel
+  // is when a checkbox is a subfilter of a multifilter.
+  // In that case, the multifilter explicitly sets the label and the checkbox
+  // passes that value through via the event options.
+  // Subfilters don't add listeners that trigger this handler, so it will only
+  // be called by the MultiFilter.
   var $filterLabel = opts.filterLabel || this.$filterLabel;
   var filterCount = $filterLabel.find('.filter-count');
   if (filterCount.html()) {

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -6,6 +6,7 @@ var URI = require('urijs');
 
 var TextFilter = require('./text-filter').TextFilter;
 var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
+var MultiFilter = require('./filter-base').MultiFilter;
 var TypeaheadFilter = require('./typeahead-filter').TypeaheadFilter;
 var SelectFilter = require('./select-filter').SelectFilter;
 var DateFilter = require('./date-filter').DateFilter;
@@ -28,6 +29,7 @@ var filterMap = {
   'date': DateFilter,
   'typeahead': TypeaheadFilter,
   'election': ElectionFilter,
+  'multi': MultiFilter,
   'select': SelectFilter,
   'toggle': ToggleFilter,
   'range': RangeFilter,

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -6,7 +6,7 @@ var URI = require('urijs');
 
 var TextFilter = require('./text-filter').TextFilter;
 var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
-var MultiFilter = require('./filter-base').MultiFilter;
+var MultiFilter = require('./multi-filter').MultiFilter;
 var TypeaheadFilter = require('./typeahead-filter').TypeaheadFilter;
 var SelectFilter = require('./select-filter').SelectFilter;
 var DateFilter = require('./date-filter').DateFilter;

--- a/js/multi-filter.js
+++ b/js/multi-filter.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var $ = require('jquery');
+var Filter = require('./filter-base.js').Filter;
+var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
+
+/* MultiFilters used when there are multiple filters that share the
+ * same name attribute
+*/
+
+function MultiFilter(elm) {
+  Filter.call(this, elm);
+  this.$subfilters = this.$elm.find('.js-sub-filter[data-name="' + this.name + '"]');
+
+  this.$subfilters.each(function() {
+    new CheckboxFilter(this);
+  });
+}
+
+MultiFilter.prototype = Object.create(Filter.prototype);
+MultiFilter.constructor = MultiFilter;
+
+module.exports = {
+  MultiFilter: MultiFilter
+};

--- a/js/multi-filter.js
+++ b/js/multi-filter.js
@@ -13,7 +13,10 @@ function MultiFilter(elm) {
   this.$subfilters = this.$elm.find('.js-sub-filter[data-name="' + this.name + '"]');
 
   this.$subfilters.each(function() {
-    new CheckboxFilter(this);
+    var subfilter = new CheckboxFilter(this);
+    // Explicitly assign filterLabel, which will show the count
+    // Necessary because each subfilter may be part of a different accordion
+    subfilter.$filterLabel = $('#' + subfilter.$elm.data('filter-label'));
   });
 }
 

--- a/js/multi-filter.js
+++ b/js/multi-filter.js
@@ -10,18 +10,31 @@ var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
 
 function MultiFilter(elm) {
   Filter.call(this, elm);
-  this.$subfilters = this.$elm.find('.js-sub-filter[data-name="' + this.name + '"]');
-
-  this.$subfilters.each(function() {
-    var subfilter = new CheckboxFilter(this);
-    // Explicitly assign filterLabel, which will show the count
-    // Necessary because each subfilter may be part of a different accordion
-    subfilter.$filterLabel = $('#' + subfilter.$elm.data('filter-label'));
-  });
+  this.subfilters = this.activateSubfilters();
 }
 
 MultiFilter.prototype = Object.create(Filter.prototype);
 MultiFilter.constructor = MultiFilter;
+
+MultiFilter.prototype.activateSubfilters = function() {
+  var subfilters = [];
+  // Activate each sub-filter and add it to an array
+  this.$elm.find('.js-sub-filter[data-name="' + this.name + '"]').each(function() {
+    var subfilter = new CheckboxFilter(this);
+    // Explicitly assign filterLabel, which will show the count
+    // Necessary because each subfilter may be part of a different accordion
+    subfilter.$filterLabel = $('#' + subfilter.$elm.data('filter-label'));
+    subfilters.push(subfilter);
+  });
+
+  return subfilters;
+};
+
+MultiFilter.prototype.fromQuery = function(query) {
+  this.subfilters.forEach(function(filter) {
+    filter.fromQuery(query);
+  });
+};
 
 module.exports = {
   MultiFilter: MultiFilter

--- a/tests/checkbox-filter.js
+++ b/tests/checkbox-filter.js
@@ -19,6 +19,10 @@ describe('checkbox filters', function() {
   });
 
   beforeEach(function() {
+    $(document.body).off('filter:added');
+    $(document.body).off('filter:removed');
+    $(document.body).off('filter:changed');
+
     this.$fixture.empty().append(
       '<button class="accordion__trigger">Filter category</button>' +
       '<div class="accordion__content">' +

--- a/tests/checkbox-filter.js
+++ b/tests/checkbox-filter.js
@@ -97,7 +97,8 @@ describe('checkbox filters', function() {
           key: 'president',
           value: 'President',
           loadedOnce: false,
-          name: 'office'
+          filterLabel: this.filter.$filterLabel,
+          name: 'office',
         }
       ]);
     });
@@ -109,6 +110,7 @@ describe('checkbox filters', function() {
           key: 'president',
           value: 'President',
           loadedOnce: false,
+          filterLabel: this.filter.$filterLabel,
           name: 'office'
         }
       ]);

--- a/tests/multi-filter.js
+++ b/tests/multi-filter.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var chai = require('chai');
+var sinonChai = require('sinon-chai');
+var expect = chai.expect;
+chai.use(sinonChai);
+
+var $ = require('jquery');
+
+require('./setup')();
+
+var MultiFilter = require('../js/multi-filter').MultiFilter;
+
+describe('MultiFilter', function() {
+  before(function() {
+    this.$fixture = $('<div id="fixtures"></div>');
+    $('body').append(this.$fixture);
+  });
+
+  beforeEach(function() {
+    this.$fixture.empty().append(
+      '<div class="js-filter" data-name="category" data-filter="multi">'+
+      '<button class="accordion__trigger" id="label-1">Reports</button>' +
+      '<div class="accordion__content">' +
+        '<div class="js-sub-filter" data-filter-label="label-1" data-name="category">' +
+          '<input id="president" name="category" type="checkbox" value="m">' +
+          '<label for="president">Monthly</label>' +
+          '<input id="senate" name="category" type="checkbox" value="q">' +
+          '<label for="senate">Quarterly</label>' +
+        '</div>' +
+      '</div>' +
+      '<button class="accordion__trigger" id="label-2">Events</button>' +
+      '<div class="accordion__content">' +
+        '<div class="js-sub-filter" data-filter-label="label-2" data-name="category">' +
+          '<input id="president" name="category" type="checkbox" value="o">' +
+          '<label for="president">Open meeting</label>' +
+          '<input id="senate" name="category" type="checkbox" value="w">' +
+          '<label for="senate">Webinar</label>' +
+        '</div>' +
+      '</div>'
+    );
+    this.filter = new MultiFilter(this.$fixture.find('.js-filter'));
+  });
+
+  it('locates dom elements', function() {
+    expect(this.filter.$elm.is('#fixtures .js-filter')).to.be.true;
+  });
+
+  it('finds all subfilters', function() {
+    expect(this.filter.subfilters.length).to.equal(2);
+  });
+
+  it('sets the correct label for each subfilter', function() {
+    var subfilter = this.filter.subfilters[0];
+    var label = $('#label-1');
+    expect(subfilter.$filterLabel.is(label)).to.be.true;
+  });
+});


### PR DESCRIPTION
This fixes https://github.com/18F/fec-cms/issues/618 , an issue caused by the way we were handling multiple filters that share the same `name`. 

On the calendar page, every filter except for "State" filters the API by the `category` parameter. The way we handle this is to have the `name` of the form element set to the property it filters. So all of these checkboxes are like `<input type="checkbox" name="category" value="report-Q">`.

However! The filter code we've written for everything else assumes a _unique_ `name` value for each filter component. Without it, things like the incrementing/decrementing of the count, the filter tags, and loading from the URL don't work. 

We've gone around in circles with this particular headache a couple times now. I _think_ I finally have a good solution. 

This change reintroduces the `MultiFilter` component, but with a few changes:
- MultiFilters contain subfilters, which are instances of the `CheckboxFilter` class
- MultiFilters are instantiated by the `FilterSet` class, but subfilters are not instantiated until later. This is because the `FilterSet` can't handle multiple instances of a `Filter` object with the same `name`
- Instead, subfilters are then instantiated by the `MultiFilter` and are stored in an array as a property
- The `MultiFilter` also has its own `fromQuery` method that passes the query through to each `CheckboxFilter` subfilter
- Last, subfilters need to have their `filterLabel` (i.e. the accordion button that contains the number) explicitly defined on their element), so this gets set when they're instantiated

This feels a little over-engineered, but after working on it for the better part of today I'm just not sure what a better approach is, but certainly open to alternatives. 