### PR TITLE
Calendar fix

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -14,10 +14,10 @@ var LOADING_DELAY = 1500;
 var SUCCESS_DELAY = 5000;
 
 var formatMap = {
-  default: 'MM-DD-YYYY',
-  pretty: 'MMM D, YYYY',
+  default: 'MM/DD/YYYY',
+  pretty: 'MMMM D, YYYY',
   time: 'h:mma',
-  dateTime: 'MMM D, h:mma',
+  dateTime: 'MMMM D, h:mma',
   dayOfWeek: 'ddd',
   fullDayOfWeek: 'dddd'
 };

--- a/scss/modules/_calendar.scss
+++ b/scss/modules/_calendar.scss
@@ -500,6 +500,7 @@
   width: u(22rem);
 
   .fc-header {
+    @include clearfix();
     background: $neutral;
     padding: u(3px .5rem);
 


### PR DESCRIPTION
This fixes a couple small style and date formatting things I noticed on the calendar:

- Fixes the titles of the "More" popups:
![image](https://cloud.githubusercontent.com/assets/1696495/21200563/8c767630-c1fc-11e6-9e72-baf91e934365.png)
- Fixes the date formats throughout to use `MM/DD/YYYY` and full month names
