### PR TITLE
Data type toggle

### DIFF
--- a/js/dropdowns.js
+++ b/js/dropdowns.js
@@ -157,10 +157,11 @@ Dropdown.prototype.handleRemoveClick = function(e, opts) {
 // "Clear all filters" will remove unchecked dropdown checkboxes
 Dropdown.prototype.handleClearFilters = function() {
   var self = this;
-
-  this.$selected.find('input:checkbox:not(:checked)').each(function () {
-    self.handleCheckboxRemoval($(this));
-  });
+  if (this.$selected) {
+    this.$selected.find('input:checkbox:not(:checked)').each(function () {
+      self.handleCheckboxRemoval($(this));
+    });
+  }
 };
 
 Dropdown.prototype.selectItem = function($input) {

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -11,9 +11,10 @@ var defaultOptions = {
   body: '.filters',
   content: '.filters__content',
   dataContainer: '.data-container',
+  filterHeader: '.js-filter-header',
   form: '#category-filters',
   focus: '.js-filter-toggle',
-  toggle: '.js-filter-toggle',
+  toggle: '.js-filter-toggle'
 };
 
 function FilterPanel(options) {
@@ -26,6 +27,7 @@ function FilterPanel(options) {
   this.$form = $(this.options.form);
   this.$focus = $(this.options.focus);
   this.$toggle = $(this.options.toggle);
+  this.$filterHeader = $(this.options.filterHeader);
 
   this.$toggle.on('click', this.toggle.bind(this));
   this.$body.on('filter:added', this.handleAddEvent.bind(this));
@@ -79,20 +81,20 @@ FilterPanel.prototype.toggle = function() {
 };
 
 FilterPanel.prototype.handleAddEvent = function() {
-  var filterCount = this.$toggle.find('.filter-count');
+  var filterCount = this.$filterHeader.find('.filter-count');
 
   if (filterCount.html()) {
     filterCount.html(parseInt(filterCount.html(), 10) + 1);
   }
   else {
-    this.$toggle.append(' <span class="filter-count">1</span>');
+    this.$filterHeader.append(' <span class="filter-count">1</span>');
   }
 };
 
 FilterPanel.prototype.handleRemoveEvent = function(e, opts) {
   if (opts.loadedOnce !== true) { return; }
 
-  var filterCount = this.$toggle.find('.filter-count');
+  var filterCount = this.$filterHeader.find('.filter-count');
 
   if (filterCount.html() === '1') {
     filterCount.remove();

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -33,7 +33,7 @@ function FilterPanel(options) {
   this.$body.on('filter:added', this.handleAddEvent.bind(this));
   this.$body.on('filter:removed', this.handleRemoveEvent.bind(this));
 
-  this.filterSet = new FilterSet(this.$form).activate();
+  this.filterSet = new FilterSet(this.$form).activateAll();
 
   this.setInitialDisplay();
 }

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -100,11 +100,12 @@ FilterSet.prototype.handleValidation = function(e, opts) {
 FilterSet.prototype.switchFilters = function(dataType) {
   // Save the current query for later
   var query = URI.parseQuery(window.location.search);
-  var $currentFilters = this.$body.find('.js-' + dataType + '-filters');
+  var currentFilters = '.js-' + dataType + '-filters';
   var otherFilters = dataType == 'efiling' ? '.js-processed-filters' : '.js-efiling-filters';
+
   // Toggle visibility of filters
   this.$body.find(otherFilters).attr('aria-hidden', true);
-  $currentFilters.attr('aria-hidden', false);
+  this.$body.find(currentFilters).attr('aria-hidden', false);
   this.$body.trigger('tag:removeAll');
 
   // If there was a previous query, activate filters
@@ -112,7 +113,7 @@ FilterSet.prototype.switchFilters = function(dataType) {
     var previousQuery = this.previousQuery;
     _.each(this.filters, function(filter) {
       // Set the value if it's in the current filter set
-      if (filter.$elm.closest('.js-filters').is($currentFilters)) {
+      if (filter.$elm.closest('.js-' + dataType + '-filters').length > 0) {
         filter.fromQuery(previousQuery);
       }
     });

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -18,9 +18,14 @@ function FilterSet(elm) {
   this.$body = $(elm);
   $(document.body).on('tag:removed', this.handleTagRemove.bind(this));
   this.$body.on('filters:validation', this.handleValidation.bind(this));
-  this.filters = {};
+  this.efiling = this.$body.data('efiling-filters') || false;
+
   this.fields = [];
   this.isValid = true;
+  this.firstLoad = true;
+  this.filters = {};
+  this.efilingFilters = {};
+  this.processedFilters = {};
 }
 
 var filterMap = {
@@ -41,25 +46,59 @@ FilterSet.prototype.buildFilter = function($elm) {
   return new F($elm);
 };
 
-FilterSet.prototype.activate = function() {
+FilterSet.prototype.activate = function($selector) {
   var self = this;
   var query = URI.parseQuery(window.location.search);
-  if (_.isEmpty(this.filters)) {
-    this.filters = _.chain(this.$body.find('.js-filter'))
-      .map(function(elm) {
-        var filter = self.buildFilter($(elm)); // .fromQuery(query);
-        return [filter.name, filter];
-      })
-      .object()
-      .value();
-    this.fields = _.chain(this.filters)
-      .pluck('fields')
-      .flatten()
-      .value();
-  }
-  _.each(this.filters, function(filter) {
+  var filters = _.chain($selector)
+    .map(function(elm) {
+      var filter = self.buildFilter($(elm)); // .fromQuery(query);
+      return [filter.name, filter];
+    })
+    .object()
+    .value();
+  var fields = _.chain(filters)
+    .pluck('fields')
+    .flatten()
+    .value();
+
+  // Activate each filter
+  _.each(filters, function(filter) {
     filter.fromQuery(query);
   });
+
+  // Store all field key-values in this.fields and return the filters object
+  this.fields = this.fields.concat(fields);
+  return filters;
+};
+
+FilterSet.prototype.activateProcessed = function() {
+  var $filters = this.$body.find('.js-processed-filters .js-filter');
+  if (_.isEmpty(this.processedFilters)) {
+    this.processedFilters = this.activate($filters);
+  }
+};
+
+FilterSet.prototype.activateEfiling = function() {
+  var $filters = this.$body.find('.js-efiling-filters .js-filter');
+  if (_.isEmpty(this.efilingFilters)) {
+    this.efilingFilters = this.activate($filters);
+  }
+};
+
+FilterSet.prototype.activateDataType = function() {
+  var $filter = this.$body.find('#data-type-toggle .js-filter');
+  this.activate($filter);
+};
+
+FilterSet.prototype.activateAll = function() {
+  // If the panel uses efiling filters, activate each separately
+  if (this.efiling) {
+    this.activateProcessed();
+    this.activateEfiling();
+    this.activateDataType();
+  } else {
+    this.filters = this.activate(this.$body.find('.js-filter'));
+  }
   return this;
 };
 
@@ -98,29 +137,39 @@ FilterSet.prototype.handleValidation = function(e, opts) {
 };
 
 FilterSet.prototype.switchFilters = function(dataType) {
-  // Save the current query for later
-  var query = URI.parseQuery(window.location.search);
+  // Identify which filter group to show and which to hide
   var currentFilters = '.js-' + dataType + '-filters';
   var otherFilters = dataType == 'efiling' ? '.js-processed-filters' : '.js-efiling-filters';
 
   // Toggle visibility of filters
   this.$body.find(otherFilters).attr('aria-hidden', true);
   this.$body.find(currentFilters).attr('aria-hidden', false);
-  this.$body.trigger('tag:removeAll');
 
-  // If there was a previous query, activate filters
-  if (this.previousQuery) {
-    var previousQuery = this.previousQuery;
+  // Clear all filters by firing this event
+  this.$body.trigger('tag:removeAll');
+  this.activateSwitchedFilters(dataType);
+};
+
+FilterSet.prototype.activateSwitchedFilters = function(dataType) {
+  // Save the current query for later
+  var query = URI.parseQuery(window.location.search);
+  // Identify which set of filters to activate and store as this.filters
+  this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
+
+  // If this is the first page load OR there's a previous query, activate filters
+  // This way we don't activate the initial query when toggling data type for the first time
+  if (this.firstLoad || this.previousQuery['data_type'] == dataType) {
+    var previousQuery = this.previousQuery || query;
+
     _.each(this.filters, function(filter) {
-      // Set the value if it's in the current filter set
-      if (filter.$elm.closest('.js-' + dataType + '-filters').length > 0) {
-        filter.fromQuery(previousQuery);
-      }
+      filter.fromQuery(previousQuery);
     });
+
   }
 
-  // Store the previous query for future reference
+  // Store the query for future reference
   this.previousQuery = query;
+  this.firstLoad = false;
 };
 
 module.exports = {FilterSet: FilterSet};

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -97,23 +97,29 @@ FilterSet.prototype.handleValidation = function(e, opts) {
   this.isValid = opts.isValid;
 };
 
-FilterSet.prototype.disableFilters = function(excludedFilters) {
-  _.each(this.filters, function(filter) {
-    if (excludedFilters.indexOf(filter.name) < 0) {
-      filter.disable();
-    }
-  });
-};
-
-FilterSet.prototype.enableFilters = function() {
-  _.each(this.filters, function(filter) {
-    filter.enable();
-  });
-};
-
 FilterSet.prototype.switchFilters = function(dataType) {
-  this.$body.find('.js-filters').attr('aria-hidden', true);
-  this.$body.find('.js-filters[data-filters-data="' + dataType + '"]').attr('aria-hidden', false);
+  // Save the current query for later
+  var query = URI.parseQuery(window.location.search);
+  var $currentFilters = this.$body.find('.js-' + dataType + '-filters');
+  var otherFilters = dataType == 'efiling' ? '.js-processed-filters' : '.js-efiling-filters';
+  // Toggle visibility of filters
+  this.$body.find(otherFilters).attr('aria-hidden', true);
+  $currentFilters.attr('aria-hidden', false);
+  this.$body.trigger('tag:removeAll');
+
+  // If there was a previous query, activate filters
+  if (this.previousQuery) {
+    var previousQuery = this.previousQuery;
+    _.each(this.filters, function(filter) {
+      // Set the value if it's in the current filter set
+      if (filter.$elm.closest('.js-filters').is($currentFilters)) {
+        filter.fromQuery(previousQuery);
+      }
+    });
+  }
+
+  // Store the previous query for future reference
+  this.previousQuery = query;
 };
 
 module.exports = {FilterSet: FilterSet};

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -158,7 +158,7 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
 
   // If this is the first page load OR there's a previous query, activate filters
   // This way we don't activate the initial query when toggling data type for the first time
-  if (this.firstLoad || this.previousQuery['data_type'] == dataType) {
+  if (this.firstLoad || this.previousQuery.data_type == dataType) {
     var previousQuery = this.previousQuery || query;
 
     _.each(this.filters, function(filter) {

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -111,4 +111,9 @@ FilterSet.prototype.enableFilters = function() {
   });
 };
 
+FilterSet.prototype.switchFilters = function(dataType) {
+  this.$body.find('.js-filters').attr('aria-hidden', true);
+  this.$body.find('.js-filters[data-filters-data="' + dataType + '"]').attr('aria-hidden', false);
+};
+
 module.exports = {FilterSet: FilterSet};

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -155,16 +155,14 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   var query = URI.parseQuery(window.location.search);
   // Identify which set of filters to activate and store as this.filters
   this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
-
   // If this is the first page load OR there's a previous query, activate filters
   // This way we don't activate the initial query when toggling data type for the first time
-  if (this.firstLoad || this.previousQuery.data_type == dataType) {
+  if (this.firstLoad || this.previousQuery.data_type === dataType) {
     var previousQuery = this.previousQuery || query;
 
     _.each(this.filters, function(filter) {
       filter.fromQuery(previousQuery);
     });
-
   }
 
   // Store the query for future reference

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -47,10 +47,11 @@ function TagList(opts) {
     .on('filter:removed', this.removeTagEvt.bind(this))
     .on('filter:renamed', this.renameTag.bind(this))
     .on('filter:disabled', this.disableTag.bind(this))
-    .on('filter:enabled', this.enableTag.bind(this));
+    .on('filter:enabled', this.enableTag.bind(this))
+    .on('tag:removeAll', this.removeAllTags.bind(this));
 
   this.$list.on('click', '.js-close', this.removeTagDom.bind(this));
-  this.$clear.on('click', this.removeAllTags.bind(this));
+  this.$clear.on('click', this.removeAllTags.bind(this, true));
 
   if (this.opts.showResultCount) {
     this.$body.find('.js-count').attr('aria-hidden', false);
@@ -123,14 +124,18 @@ TagList.prototype.removeTag = function(key, emit) {
   }
 };
 
-TagList.prototype.removeAllTags = function() {
+TagList.prototype.removeAllTags = function(e, emit) {
   var self = this;
 
   this.$list.find('[data-removable]').each(function(){
     self.removeTag($(this).data('id'), true);
   });
 
-  $(document.body).trigger('tag:removeAll');
+  // Don't emit another event unless told to do so
+  // This way it can be triggered as an event listener without creating more
+  if (emit) {
+    $(document.body).trigger('tag:removeAll');
+  }
 };
 
 TagList.prototype.removeTagEvt = function(e, opts) {
@@ -152,14 +157,12 @@ TagList.prototype.renameTag = function(e, opts) {
 
 TagList.prototype.disableTag = function(e, opts) {
   var $tag = this.$list.find('[data-id="' + opts.key + '"]');
-  $tag.addClass('is-disabled');
-  $tag.attr('title', 'This filter is not available for electronic filings data');
+  $tag.closest('.tag__category').hide();
 };
 
 TagList.prototype.enableTag = function(e, opts) {
   var $tag = this.$list.find('[data-id="' + opts.key + '"]');
-  $tag.removeClass('is-disabled');
-  $tag.attr('title', false);
+  $tag.closest('.tag__category').show();
 };
 
 module.exports = {TagList: TagList};

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "less": "^2.5.1",
     "mocha": "^2.2.5",
     "node-sass": "^3.2.0",
-    "phantomjs": "^1.9.18",
+    "phantomjs": "^2.1.3",
     "sinon": "^1.16.1",
     "sinon-chai": "^2.8.0",
     "watch": "^0.16.0"

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -398,3 +398,20 @@ $filter-button-width: u(4.6rem);
     display: none;
   }
 }
+
+.data-type {
+  border-top: 1px solid $gray-dark;
+  border-bottom: 1px solid $gray-dark;
+  margin-top: -1px; // To line up the border
+}
+
+.data-type__message {
+  padding-top: u(1rem);
+
+  p {
+    font-size: u(1.2rem);
+    font-family: $sans-serif;
+    letter-spacing: -.3px;
+    margin: 0;
+  }
+}

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -41,7 +41,7 @@ $filter-button-width: u(4.6rem);
       width: calc(100% - 7rem);
     }
 
-    .filters__header {
+    .filters__toggle {
       &::after {
         @include u-icon($arrow-left-border, $primary, $icon-size, $icon-size);
         background-size: 65%;
@@ -146,11 +146,13 @@ $filter-button-width: u(4.6rem);
   border-top: 2px solid $primary;
   color: $primary;
   line-height: u(3rem);
-  margin-bottom: 0;
+  margin: 0;
   padding: u(1rem);
   text-align: left;
   width: 100%;
+}
 
+.filters__toggle {
   &::before {
     @include u-icon-circle($filter, $primary, $inverse, $icon-size);
     background-position: 50% 45%;

--- a/tests/filter-set.js
+++ b/tests/filter-set.js
@@ -8,67 +8,140 @@ var $ = require('jquery');
 require('./setup')();
 
 var FilterSet = require('../js/filter-set').FilterSet;
+var urls = require('../js/urls');
 
-describe('filter set', function() {
-  before(function() {
-    this.$fixture = $('<div id="fixtures"></div>');
-    $('body').append(this.$fixture);
-  });
+describe('FilterSet', function() {
+  describe('basic filter set', function() {
+    before(function() {
+      this.$fixture = $('<div id="fixtures"></div>');
+      $('body').append(this.$fixture);
+    });
 
-  beforeEach(function() {
-    this.$fixture.empty().append(
-      '<form>' +
-        '<div class="js-filter" data-filter="text">' +
-          '<input name="name">' +
-          '<button></button>' +
-        '</div>' +
-        '<div class="js-filter" data-filter="checkbox">' +
-          '<input name="cycle" type="checkbox" value="2012" />' +
-          '<input name="cycle" type="checkbox" value="2014" />' +
-          '<input name="cycle" type="checkbox" value="2016" />' +
-        '</div>' +
-      '</form>'
-    );
-    this.filterSet = new FilterSet(this.$fixture.find('form'));
-  });
+    beforeEach(function() {
+      this.$fixture.empty().append(
+        '<form>' +
+          '<div class="js-filter" data-filter="text">' +
+            '<input name="name">' +
+            '<button></button>' +
+          '</div>' +
+          '<div class="js-filter" data-filter="checkbox">' +
+            '<input name="cycle" type="checkbox" value="2012" />' +
+            '<input name="cycle" type="checkbox" value="2014" />' +
+            '<input name="cycle" type="checkbox" value="2016" />' +
+          '</div>' +
+        '</form>'
+      );
+      this.filterSet = new FilterSet(this.$fixture.find('form'));
+    });
 
-  it('locates dom elements', function() {
-    expect(this.filterSet.$body.is('#fixtures form')).to.be.true;
-    expect(this.filterSet.filters).to.deep.equal({});
-    expect(this.filterSet.fields).to.deep.equal([]);
-  });
+    it('locates dom elements', function() {
+      expect(this.filterSet.$body.is('#fixtures form')).to.be.true;
+      expect(this.filterSet.filters).to.deep.equal({});
+      expect(this.filterSet.fields).to.deep.equal([]);
+    });
 
-  it('activates nested fields', function() {
-    this.filterSet.activate();
-    expect(this.filterSet.filters).to.include.keys('name', 'cycle');
-    expect(this.filterSet.fields).to.deep.equal(['name', 'cycle']);
-  });
+    it('activates nested fields', function() {
+      this.filterSet.activateAll();
+      expect(this.filterSet.filters).to.include.keys('name', 'cycle');
+      expect(this.filterSet.fields).to.deep.equal(['name', 'cycle']);
+    });
 
-  it('sets initial values on nested fields', function() {
-    window.history.replaceState({}, null, '?cycle=2012&cycle=2014');
-    this.filterSet.activate();
-    expect(
-      this.filterSet.filters.cycle.$input.filter(function(idx, elm) {
-        return $(elm).is(':checked');
-      }).map(function(idx, elm) {
-        return $(elm).val();
-      }).get()
-    ).to.deep.equal(['2012', '2014']);
-  });
+    it('sets initial values on nested fields', function() {
+      window.history.replaceState({}, null, '?cycle=2012&cycle=2014');
+      this.filterSet.activateAll();
+      expect(
+        this.filterSet.filters.cycle.$input.filter(function(idx, elm) {
+          return $(elm).is(':checked');
+        }).map(function(idx, elm) {
+          return $(elm).val();
+        }).get()
+      ).to.deep.equal(['2012', '2014']);
+    });
 
-  it('serializes form values', function() {
-    this.filterSet.activate();
-    this.filterSet.filters.cycle.setValue(['2012', '2014']);
-    expect(this.filterSet.serialize()).to.deep.equal({
-      cycle: ['2012', '2014']
+    it('serializes form values', function() {
+      this.filterSet.activateAll();
+      this.filterSet.filters.cycle.setValue(['2012', '2014']);
+      expect(this.filterSet.serialize()).to.deep.equal({
+        cycle: ['2012', '2014']
+      });
+    });
+
+    it('clears form values', function() {
+      this.filterSet.activateAll();
+      this.filterSet.filters.name.setValue('jed');
+      this.filterSet.filters.cycle.setValue(['2012', '2014']);
+      this.filterSet.clear();
+      expect(this.filterSet.serialize()).to.deep.equal({});
     });
   });
 
-  it('clears form values', function() {
-    this.filterSet.activate();
-    this.filterSet.filters.name.setValue('jed');
-    this.filterSet.filters.cycle.setValue(['2012', '2014']);
-    this.filterSet.clear();
-    expect(this.filterSet.serialize()).to.deep.equal({});
+  describe('efiling filter set', function() {
+    before(function() {
+      this.$fixture = $('<div id="fixtures"></div>');
+      $('body').append(this.$fixture);
+    });
+
+    beforeEach(function() {
+      this.$fixture.empty().append(
+        '<form data-efiling-filters="true">' +
+        '<div class="js-processed-filters">' +
+          '<div class="js-filter" data-filter="text">' +
+            '<input name="name">' +
+            '<button></button>' +
+          '</div>' +
+          '<div class="js-filter" data-filter="checkbox">' +
+            '<input name="cycle" type="checkbox" value="2012" />' +
+            '<input name="cycle" type="checkbox" value="2014" />' +
+            '<input name="cycle" type="checkbox" value="2016" />' +
+          '</div>' +
+        '</div>' +
+        '<div class="js-efiling-filters">' +
+          '<div class="js-filter" data-filter="text">' +
+            '<input name="name">' +
+            '<button></button>' +
+          '</div>' +
+        '</div>' +
+        '</form>'
+      );
+      this.filterSet = new FilterSet(this.$fixture.find('form'));
+    });
+
+    it('activates and stores processed filters', function() {
+      this.filterSet.activateProcessed();
+      expect(Object.keys(this.filterSet.processedFilters)).to.deep.equal(['name', 'cycle']);
+    });
+
+    it('activates and stores the efiling filters', function() {
+      this.filterSet.activateEfiling();
+      expect(Object.keys(this.filterSet.efilingFilters)).to.deep.equal(['name']);
+    });
+
+    it('stores all of the field names together', function() {
+      this.filterSet.activateAll();
+      expect(this.filterSet.fields).to.deep.equal(['name', 'cycle', 'name']);
+    });
+
+    it('toggles the visibility of filter panels', function() {
+      this.filterSet.switchFilters('efiling');
+      expect(this.filterSet.$body.find('.js-processed-filters')
+        .attr('aria-hidden')).to.equal('true');
+      expect(this.filterSet.$body.find('.js-efiling-filters')
+        .attr('aria-hidden')).to.equal('false');
+    });
+
+    it('stores the current query after switching', function() {
+      window.history.replaceState({}, null, '?name=Noah');
+      this.filterSet.activateSwitchedFilters('efiling');
+      expect(this.filterSet.firstLoad).to.be.false;
+      expect(this.filterSet.previousQuery).to.deep.equal({name: 'Noah'});
+    });
+
+    it('loads from the previous query after switching', function() {
+      this.filterSet.activateAll();
+      this.filterSet.firstLoad = false;
+      this.filterSet.previousQuery = {cycle: ['2012'], data_type: 'processed'};
+      this.filterSet.activateSwitchedFilters('processed');
+      expect(this.filterSet.$body.find('.js-processed-filters input[value="2012"]').is(':checked')).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
This does a couple primary things to support the new efiling UI.

1. In `filter-panel.js` it distinguishes between the `toggle` (which is always the top button, and which is used to open and close the panel) and the `filterHeader`, which is the heading for the filters that contains the number of applied filters.

2. In `filter-set.js` I refactored the activation code so that when a filter-set has an efiling set of filters (determined by having `data-efiling-filters` set on the element), it activates the processed and the efiling and processed filters _separetly_ and stores them in distinct properties. 

That way, when `filterSet.activateSwitchedFilters()` is called, it can only set the values of those filters in the visible set. This method also stores the previous state (from the query) in order to repopulate the filters when toggling back.

3. `filter-set.js` is also the place where the visibility of the filters is toggled. `filterSet.switchFilters()` is called in `tables.js` over in `openfec-web-app`. 

4. Last, to clear all filters, `filterSet` just triggers the `tag:removeAll` event. 

Oh, and I also updated the PhantomJS number because my MacOS Sierra wasn't working with it, and this seemed to be the solution.