### PR TITLE
Positioning the mega menu above the new homepage seal

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -71,7 +71,7 @@ $z-max: 9000000;
 $z-overlay: $z2;
 $z-tooltip: $z4;
 $z-downloads: $z4;
-$z-navigation: $z5;
+$z-navigation: $z7;
 $z-header: $z6;
 $z-sticky: $z7;
 $z-glossary: $z8;

--- a/scss/modules/_nav.scss
+++ b/scss/modules/_nav.scss
@@ -198,7 +198,6 @@
   .site-nav__container {
     @include clearfix();
     @include transform(translateX(0));
-    background: $inverse;
     height: auto;
     float: left;
     overflow: visible;


### PR DESCRIPTION
This fixes the issue caused by the new homepage seal where it overlaps with the campaign finance data menu.

![image](https://cloud.githubusercontent.com/assets/1696495/21438710/52f690b8-c83f-11e6-94f7-10793d526fa7.png)
