### PR TITLE
Filter tag update

### DIFF
--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -82,7 +82,7 @@ DateFilter.prototype.handleInputChange = function(e) {
       rangeName: rangename,
       name: this.name,
       nonremovable: nonremovable,
-      removeOnSwitch: true,
+      removeOnSwitch: true
     }
   ]);
 

--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -35,6 +35,7 @@ function DateFilter(elm) {
   this.$elm.on('click', '.date-range__grid li', this.handleGridItemSelect.bind(this));
 
   $(document.body).on('filter:modify', this.handleModifyEvent.bind(this));
+  $(document.body).on('tag:removeAll', this.handleRemoveAll.bind(this));
 }
 
 DateFilter.prototype = Object.create(Filter.Filter.prototype);
@@ -80,7 +81,8 @@ DateFilter.prototype.handleInputChange = function(e) {
       range: range,
       rangeName: rangename,
       name: this.name,
-      nonremovable: nonremovable
+      nonremovable: nonremovable,
+      removeOnSwitch: true,
     }
   ]);
 
@@ -143,6 +145,18 @@ DateFilter.prototype.handleModifyEvent = function(e, opts) {
       this.$maxDate.val('12/31/' + this.maxYear.toString()).change();
     }
     this.validate();
+  }
+};
+
+DateFilter.prototype.handleRemoveAll = function(e, opts) {
+  // If this is a forceRemove event that means it was triggered by table switch
+  // So we need to clear these inputs and set had-value to false so that it fires filter:added
+  var forceRemove = opts.forceRemove || false;
+  if (forceRemove) {
+   this.$minDate.val('');
+   this.$maxDate.val('');
+   this.$minDate.data('had-value', false);
+   this.$maxDate.data('had-value', false);
   }
 };
 

--- a/js/election-filter.js
+++ b/js/election-filter.js
@@ -88,7 +88,8 @@ ElectionFilter.prototype.setTag = function() {
     {
       key: 'election',
       value: value,
-      nonremovable: true
+      nonremovable: true,
+      removeOnSwitch: false
     }
   ]);
   this.loadedOnce = true;

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -151,15 +151,21 @@ FilterSet.prototype.switchFilters = function(dataType) {
 FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   // Save the current query for later
   var query = URI.parseQuery(window.location.search);
-
-  // Identify which set of filters to activate and store as this.filters
-  this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
-
   // Clear filters if this isn't the first page load
   // Set forceRemove: true to clear date filters that are usually nonremovable
   if (!this.firstLoad) {
     this.$body.trigger('tag:removeAll', {forceRemove: true});
+    // Go through the current panel and set loaded-once on each input
+    // So that they don't show loading indicators
+    _.each(this.filters, function(filter) {
+      filter.loadedOnce = false;
+      filter.$elm.find('input').data('loaded-once', false);
+    });
   }
+
+  // Identify which set of filters to activate and store as this.filters
+  this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
+
 
   // If there's a previous query, activate filters
   // This way we don't activate the initial query when toggling data type for the first time

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -145,14 +145,19 @@ FilterSet.prototype.switchFilters = function(dataType) {
   this.$body.find(otherFilters).attr('aria-hidden', true);
   this.$body.find(currentFilters).attr('aria-hidden', false);
 
-  // Clear all filters by firing this event
-  this.$body.trigger('tag:removeAll');
   this.activateSwitchedFilters(dataType);
 };
 
 FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   // Save the current query for later
   var query = URI.parseQuery(window.location.search);
+
+  // Clear filters if this isn't the first page load
+  // Set forceRemove: true to clear date filters that are usually nonremovable
+  if (!this.firstLoad) {
+    this.$body.trigger('tag:removeAll', {forceRemove: true});
+  }
+
   // Identify which set of filters to activate and store as this.filters
   this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
   // If this is the first page load OR there's a previous query, activate filters

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -149,11 +149,11 @@ FilterSet.prototype.switchFilters = function(dataType) {
 };
 
 FilterSet.prototype.activateSwitchedFilters = function(dataType) {
-  // Don't do anything on the first load because they will already be activated
-  if (this.firstLoad) { return; }
-
   // Save the current query for later
   var query = URI.parseQuery(window.location.search);
+
+  // Identify which set of filters to activate and store as this.filters
+  this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
 
   // Clear filters if this isn't the first page load
   // Set forceRemove: true to clear date filters that are usually nonremovable
@@ -161,11 +161,9 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
     this.$body.trigger('tag:removeAll', {forceRemove: true});
   }
 
-  // Identify which set of filters to activate and store as this.filters
-  this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
   // If there's a previous query, activate filters
   // This way we don't activate the initial query when toggling data type for the first time
-  if (this.previousQuery.data_type === dataType) {
+  if (!this.firstLoad && this.previousQuery.data_type === dataType) {
     var previousQuery = this.previousQuery || query;
 
     _.each(this.filters, function(filter) {

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -149,6 +149,9 @@ FilterSet.prototype.switchFilters = function(dataType) {
 };
 
 FilterSet.prototype.activateSwitchedFilters = function(dataType) {
+  // Don't do anything on the first load because they will already be activated
+  if (this.firstLoad) { return; }
+
   // Save the current query for later
   var query = URI.parseQuery(window.location.search);
 
@@ -160,9 +163,9 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
 
   // Identify which set of filters to activate and store as this.filters
   this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
-  // If this is the first page load OR there's a previous query, activate filters
+  // If there's a previous query, activate filters
   // This way we don't activate the initial query when toggling data type for the first time
-  if (this.firstLoad || this.previousQuery.data_type === dataType) {
+  if (this.previousQuery.data_type === dataType) {
     var previousQuery = this.previousQuery || query;
 
     _.each(this.filters, function(filter) {

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -99,16 +99,13 @@ TagList.prototype.removeTagElement = function($tag, emit) {
   // This handles the actual removal of the DOM elementrs
   var $tagCategory = $tag.parent();
   var key = $tag.data('id');
-  $tag.remove();
-
-  $tagCategory.removeClass('tag__category__range--amount tag__category__range--date');
-
-  if ($tagCategory.is(':empty')) {
-    $tagCategory.remove();
-  }
-
   if (emit) {
     $tag.trigger('tag:removed', [{key: key}]);
+  }
+  $tag.remove();
+  $tagCategory.removeClass('tag__category__range--amount tag__category__range--date');
+  if ($tagCategory.is(':empty')) {
+    $tagCategory.remove();
   }
 };
 

--- a/js/filter-tags.js
+++ b/js/filter-tags.js
@@ -148,7 +148,7 @@ TagList.prototype.removeAllTags = function(e, opts, emit) {
   // Don't emit another event unless told to do so
   // This way it can be triggered as an event listener without creating more
   if (emit) {
-    $(document.body).trigger('tag:removeAll');
+    $(document.body).trigger('tag:removeAll', {removeAll: false});
   }
 };
 

--- a/js/select-filter.js
+++ b/js/select-filter.js
@@ -11,7 +11,7 @@ function SelectFilter(elm) {
   this.requiredDefault = this.$elm.data('required-default') || null; // If a default is required
   this.loadedOnce = false;
 
-  this.$input.on('change', this.handleChange.bind(this));
+  // this.$input.on('change', this.handleChange.bind(this));
   this.setRequiredDefault();
 }
 
@@ -45,7 +45,8 @@ SelectFilter.prototype.handleChange = function(e) {
       value: 'Transaction period: ' + (value - 1) + '-' + value,
       loadedOnce: this.loadedOnce,
       name: this.name,
-      nonremovable: true
+      nonremovable: true,
+      removeOnSwitch: true,
     }
   ]);
 

--- a/js/select-filter.js
+++ b/js/select-filter.js
@@ -11,7 +11,6 @@ function SelectFilter(elm) {
   this.requiredDefault = this.$elm.data('required-default') || null; // If a default is required
   this.loadedOnce = false;
 
-  // this.$input.on('change', this.handleChange.bind(this));
   this.setRequiredDefault();
 }
 
@@ -32,25 +31,6 @@ SelectFilter.prototype.setValue = function(value) {
   this.$input.find('option[selected]').attr('selected','false');
   this.$input.find('option[value="' + value + '"]').attr('selected','true');
   this.$input.change();
-};
-
-SelectFilter.prototype.handleChange = function(e) {
-  var value = $(e.target).val();
-  var id = this.$input.attr('id');
-  var eventName = this.loadedOnce ? 'filter:renamed' : 'filter:added';
-
-  this.$input.trigger(eventName, [
-    {
-      key: id,
-      value: 'Transaction period: ' + (value - 1) + '-' + value,
-      loadedOnce: this.loadedOnce,
-      name: this.name,
-      nonremovable: true,
-      removeOnSwitch: true,
-    }
-  ]);
-
-  this.loadedOnce = true;
 };
 
 module.exports = {SelectFilter: SelectFilter};

--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -8,6 +8,7 @@ var Filter = require('./filter-base.js').Filter;
 /* ToggleFilter that has to fire a custom event */
 function ToggleFilter(elm) {
   Filter.call(this, elm);
+  this.removeOnSwitch = this.$elm.data('remove-on-switch') || false;
   this.$elm.on('change', this.handleChange.bind(this));
   this.setInitialValue();
 }
@@ -30,7 +31,7 @@ ToggleFilter.prototype.handleChange = function(e) {
       loadedOnce: this.loadedOnce || false,
       name: this.name,
       nonremovable: true,
-      removeOnSwitch: false
+      removeOnSwitch: this.removeOnSwitch
     }
   ]);
 

--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -29,7 +29,8 @@ ToggleFilter.prototype.handleChange = function(e) {
       value: this.formatValue($input, value),
       loadedOnce: this.loadedOnce || false,
       name: this.name,
-      nonremovable: true
+      nonremovable: true,
+      removeOnSwitch: false
     }
   ]);
 

--- a/tests/date-filter.js
+++ b/tests/date-filter.js
@@ -128,7 +128,8 @@ describe('date filter', function() {
         range: 'min',
         rangeName: 'date',
         name: 'date',
-        nonremovable: true
+        nonremovable: true,
+        removeOnSwitch: true
       }]);
     });
 

--- a/tests/dropdowns.js
+++ b/tests/dropdowns.js
@@ -116,7 +116,7 @@ describe('dropdown', function() {
     it('clear all tags removes all selected inputs', function() {
       this.dropdown.selectItem($('#A'));
       this.dropdown.selectItem($('#B'));
-      $(document.body).trigger('tag:removeAll');
+      $(document.body).trigger('tag:removeAll', {});
       var selectedItems = this.dropdown.$selected.find('.dropdown__item');
       var panelItems = this.dropdown.$panel.find('.dropdown__item');
       expect(selectedItems.length).to.equal(0);
@@ -245,7 +245,7 @@ describe('dropdown', function() {
       this.dropdown.selectItem($('#A'));
       var selectedItems = this.dropdown.$selected.find('.dropdown__item');
       expect(selectedItems.length).to.equal(3);
-      $(document.body).trigger('tag:removeAll');
+      $(document.body).trigger('tag:removeAll', {});
       selectedItems = this.dropdown.$selected.find('.dropdown__item');
       expect(selectedItems.length).to.equal(2);
     });

--- a/tests/election-filter.js
+++ b/tests/election-filter.js
@@ -85,7 +85,8 @@ describe('Election filter', function() {
       {
         key: 'election',
         value: '2016 election: 2013-2014',
-        nonremovable: true
+        nonremovable: true,
+        removeOnSwitch: false
       }
     ]);
   });
@@ -98,7 +99,8 @@ describe('Election filter', function() {
       {
         key: 'election',
         value: '2012 election: 2013-2014',
-        nonremovable: true
+        nonremovable: true,
+        removeOnSwitch: false
       }
     ]);
   });

--- a/tests/filter-tags.js
+++ b/tests/filter-tags.js
@@ -63,7 +63,7 @@ describe('filter tags', function() {
     });
 
     it('it does not add remove button if nonremovable is true', function(){
-      $(document.body).trigger('filter:added', [{key: 'name', value: 'timmy', nonremovable: true}]);
+      $(document.body).trigger('filter:added', [{key: 'name', value: 'timmy', nonremovable: true, removeOnSwitch: false}]);
       var tag = this.tagList.$list.find('[data-id="name"]');
       expect(tag.find('button')).to.have.length(0);
     });
@@ -104,14 +104,14 @@ describe('filter tags', function() {
 
     it('clear all removes all removable tags', function() {
       this.tagList.addTag({}, {key: 'name', value: 'hillary'});
-      this.tagList.removeAllTags();
+      this.tagList.removeAllTags({}, {});
       var tags = this.tagList.$list.find('li');
       expect(tags.length).to.equal(0);
     });
 
     it('clear all does not remove a nonremovable tag', function() {
-      this.tagList.addTag({}, {key: 'name', value: 'aaron', nonremovable: true});
-      this.tagList.removeAllTags();
+      this.tagList.addTag({}, {key: 'name', value: 'aaron', nonremovable: true, removeOnSwitch: false});
+      this.tagList.removeAllTags({}, {});
       var tags = this.tagList.$list.find('li');
       expect(tags.length).to.equal(1);
     });

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -87,7 +87,8 @@ describe('checkbox filters', function() {
           value: '<span class="prefix">Data type: </span>processed',
           loadedOnce: false,
           name: 'data_type',
-          nonremovable: true
+          nonremovable: true,
+          removeOnSwitch: false
         }
       ]);
     });
@@ -100,7 +101,8 @@ describe('checkbox filters', function() {
           value: '<span class="prefix">Data type: </span>electronic filings',
           loadedOnce: true,
           name: 'data_type',
-          nonremovable: true
+          nonremovable: true,
+          removeOnSwitch: false
         }
       ]);
     });


### PR DESCRIPTION
This change is to accommodate the fact that when switching between processed and raw filters, sometimes tags that are otherwise non-removable (like dates) will need to be removed because the filter doesn't exist on the other data type. For example, this is the processed view for receipts:
![image](https://cloud.githubusercontent.com/assets/1696495/21912971/42adec4c-d8de-11e6-93c5-18acbeb0ffa1.png)

And this is raw:
![image](https://cloud.githubusercontent.com/assets/1696495/21912975/48e77e02-d8de-11e6-931e-67deda612671.png)

To do this I added:
- A new option to pass in the `tag:removeAll` event for `forceRemove` which tells the filter tags to remove any that can be removed on the data type switch
- I added a new data attribute `data-remove-on-switch` that's added to "nonremovable" tags, which means that they can be cleared when `forceRemove = true`. 
- Added a remove handler to the date filter to actually clear those filters