### PR TITLE
Set max width on filter selects

### DIFF
--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -238,6 +238,10 @@ $filter-button-width: u(4.6rem);
     line-height: 1;
   }
 
+  select {
+    max-width: 26rem;
+  }
+
   [type="text"],
   select,
   .dropdown__button {


### PR DESCRIPTION
This fixes a bug where if a select has a really long option, it forces the width of the entire filter panel to be too wide.

cc @anthonygarvan