### PR TITLE
Fixing the accuracy of the filter count

### DIFF
--- a/js/date-filter.js
+++ b/js/date-filter.js
@@ -152,11 +152,16 @@ DateFilter.prototype.handleRemoveAll = function(e, opts) {
   // If this is a forceRemove event that means it was triggered by table switch
   // So we need to clear these inputs and set had-value to false so that it fires filter:added
   var forceRemove = opts.forceRemove || false;
+
+  function remove($filter) {
+    $filter.val('');
+    $filter.data('had-value', false);
+    $filter.trigger('filter:removed', {loadedOnce: true});
+  }
+
   if (forceRemove) {
-   this.$minDate.val('');
-   this.$maxDate.val('');
-   this.$minDate.data('had-value', false);
-   this.$maxDate.data('had-value', false);
+   remove(this.$minDate);
+   remove(this.$maxDate);
   }
 };
 

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -80,7 +80,10 @@ FilterPanel.prototype.toggle = function() {
   }
 };
 
-FilterPanel.prototype.handleAddEvent = function() {
+FilterPanel.prototype.handleAddEvent = function(e, opts) {
+  // If it's a data-type toggle, we tell it to ignore for the count of active filters
+  if (opts.ignoreCount) { return; }
+
   var filterCount = this.$filterHeader.find('.filter-count');
 
   if (filterCount.html()) {

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -91,10 +91,9 @@ FilterSet.prototype.activateDataType = function() {
 };
 
 FilterSet.prototype.activateAll = function() {
-  // If the panel uses efiling filters, activate each separately
+  // If the panel uses efiling filters, activate the data type filter
+  // and activate the others when necessary
   if (this.efiling) {
-    this.activateProcessed();
-    this.activateEfiling();
     this.activateDataType();
   } else {
     this.filters = this.activate(this.$body.find('.js-filter'));
@@ -145,6 +144,13 @@ FilterSet.prototype.switchFilters = function(dataType) {
   this.$body.find(otherFilters).attr('aria-hidden', true);
   this.$body.find(currentFilters).attr('aria-hidden', false);
 
+  // If necessary activate the filters
+  if (dataType === 'efiling' && _.isEmpty(this.efilingFilters)) {
+    this.activateEfiling();
+  } else if (dataType === 'processed' && _.isEmpty(this.processedFilters)) {
+    this.activateProcessed();
+  }
+
   this.activateSwitchedFilters(dataType);
 };
 
@@ -165,7 +171,6 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
 
   // Identify which set of filters to activate and store as this.filters
   this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
-
 
   // If there's a previous query, activate filters
   // This way we don't activate the initial query when toggling data type for the first time

--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -11,6 +11,7 @@ function ToggleFilter(elm) {
   this.removeOnSwitch = this.$elm.data('remove-on-switch') || false;
   this.ignoreCount = this.$elm.data('filter-ignore-count') || false;
   this.$elm.on('change', this.handleChange.bind(this));
+  this.setInitialValue();
 }
 
 ToggleFilter.prototype = Object.create(Filter.prototype);
@@ -18,9 +19,6 @@ ToggleFilter.constructor = ToggleFilter;
 
 ToggleFilter.prototype.fromQuery = function(query) {
   this.$elm.find('input[value="' + query[this.name] + '"]').prop('checked', true).change();
-  if (!query[this.name]) {
-    this.setInitialValue();
-  }
 };
 
 ToggleFilter.prototype.handleChange = function(e) {

--- a/js/toggle-filter.js
+++ b/js/toggle-filter.js
@@ -9,8 +9,8 @@ var Filter = require('./filter-base.js').Filter;
 function ToggleFilter(elm) {
   Filter.call(this, elm);
   this.removeOnSwitch = this.$elm.data('remove-on-switch') || false;
+  this.ignoreCount = this.$elm.data('filter-ignore-count') || false;
   this.$elm.on('change', this.handleChange.bind(this));
-  this.setInitialValue();
 }
 
 ToggleFilter.prototype = Object.create(Filter.prototype);
@@ -18,6 +18,9 @@ ToggleFilter.constructor = ToggleFilter;
 
 ToggleFilter.prototype.fromQuery = function(query) {
   this.$elm.find('input[value="' + query[this.name] + '"]').prop('checked', true).change();
+  if (!query[this.name]) {
+    this.setInitialValue();
+  }
 };
 
 ToggleFilter.prototype.handleChange = function(e) {
@@ -31,7 +34,8 @@ ToggleFilter.prototype.handleChange = function(e) {
       loadedOnce: this.loadedOnce || false,
       name: this.name,
       nonremovable: true,
-      removeOnSwitch: this.removeOnSwitch
+      removeOnSwitch: this.removeOnSwitch,
+      ignoreCount: this.ignoreCount
     }
   ]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-style",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "description": "Shared styles for FEC Beta",
   "repository": {
     "type": "git",

--- a/tests/filter-set.js
+++ b/tests/filter-set.js
@@ -116,9 +116,9 @@ describe('FilterSet', function() {
       expect(Object.keys(this.filterSet.efilingFilters)).to.deep.equal(['name']);
     });
 
-    it('stores all of the field names together', function() {
+    it('does not activate filters if it has efiling filters', function() {
       this.filterSet.activateAll();
-      expect(this.filterSet.fields).to.deep.equal(['name', 'cycle', 'name']);
+      expect(this.filterSet.fields).to.deep.equal([]);
     });
 
     it('toggles the visibility of filter panels', function() {
@@ -140,7 +140,7 @@ describe('FilterSet', function() {
       this.filterSet.activateAll();
       this.filterSet.firstLoad = false;
       this.filterSet.previousQuery = {cycle: ['2012'], data_type: 'processed'};
-      this.filterSet.activateSwitchedFilters('processed');
+      this.filterSet.switchFilters('processed');
       expect(this.filterSet.$body.find('.js-processed-filters input[value="2012"]').is(':checked')).to.be.true;
     });
   });

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -58,8 +58,7 @@ describe('toggle filters', function() {
     expect(this.filter.$elm.find('#efiling').is(':checked')).to.be.true;
   });
 
-  it('calls handleChange() if no query matches', function() {
-    this.filter.fromQuery({'x': 'y'});
+  it('calls handleChange() on initial load', function() {
     expect(this.handleChange).to.have.been.called;
   });
 
@@ -73,7 +72,6 @@ describe('toggle filters', function() {
       this.trigger = sinon.spy($.prototype, 'trigger');
       this.$fixture.empty().append(DOM);
       this.filter = new ToggleFilter(this.$fixture.find('.js-filter'));
-      this.filter.fromQuery({});
     });
 
     afterEach(function() {

--- a/tests/toggle-filter.js
+++ b/tests/toggle-filter.js
@@ -11,7 +11,7 @@ var $ = require('jquery');
 require('./setup')();
 
 var ToggleFilter = require('../js/toggle-filter').ToggleFilter;
-var DOM = '<fieldset class="js-filter">' +
+var DOM = '<fieldset class="js-filter" data-filter-ignore-count="true">' +
             '<legend class="label">Data type</legend>' +
             '<label for="processed">' +
               '<input type="radio" value="processed" id="processed" checked name="data_type" data-prefix="Data type:" data-tag-value="processed">' +
@@ -23,7 +23,7 @@ var DOM = '<fieldset class="js-filter">' +
             '</label>' +
           '</fieldset>';
 
-describe('checkbox filters', function() {
+describe('toggle filters', function() {
   before(function() {
     this.$fixture = $('<div id="fixtures"></div>');
     $('body').append(this.$fixture);
@@ -46,6 +46,8 @@ describe('checkbox filters', function() {
 
   it('sets its initial state', function() {
     expect(this.filter.name).to.equal('data_type');
+    expect(this.filter.ignoreCount).to.be.true;
+    expect(this.filter.removeOnSwitch).to.be.false;
     expect(this.filter.fields).to.deep.equal(['data_type']);
   });
 
@@ -56,7 +58,8 @@ describe('checkbox filters', function() {
     expect(this.filter.$elm.find('#efiling').is(':checked')).to.be.true;
   });
 
-  it('calls handleChange() on initial load', function() {
+  it('calls handleChange() if no query matches', function() {
+    this.filter.fromQuery({'x': 'y'});
     expect(this.handleChange).to.have.been.called;
   });
 
@@ -70,6 +73,7 @@ describe('checkbox filters', function() {
       this.trigger = sinon.spy($.prototype, 'trigger');
       this.$fixture.empty().append(DOM);
       this.filter = new ToggleFilter(this.$fixture.find('.js-filter'));
+      this.filter.fromQuery({});
     });
 
     afterEach(function() {
@@ -88,7 +92,8 @@ describe('checkbox filters', function() {
           loadedOnce: false,
           name: 'data_type',
           nonremovable: true,
-          removeOnSwitch: false
+          removeOnSwitch: false,
+          ignoreCount: true
         }
       ]);
     });
@@ -102,7 +107,8 @@ describe('checkbox filters', function() {
           loadedOnce: true,
           name: 'data_type',
           nonremovable: true,
-          removeOnSwitch: false
+          removeOnSwitch: false,
+          ignoreCount: true
         }
       ]);
     });


### PR DESCRIPTION
This fixes a few unrelated bugs that occur when toggling between raw and processed filters which cause the number in the filter panel to be inaccurate:

- The `FilterSet` no longer activates both sets of filters on initalization. Instead, it activates the `DataType` toggle, which then activate whichever set of filters it needs. This is because some filters have default values when initialized, so they were being initialized -> triggering `filter:added` events -> inflating the number, but weren't actually visible
- When clearing date filters, it now triggers the `filter:removed` event to decrement the number
- The `ToggleFilter` class now can have a `ignoreCount` property set, and if this is passed in the `filter:added` event to `FilterSet` then the count isn't incremented. This is because we don't want the DataType filter to actually increase the number. This requires a small change on the web app.