### PR TITLE
Fixing home hero styles for better responsiveness + short text

### DIFF
--- a/scss/modules/_hero.scss
+++ b/scss/modules/_hero.scss
@@ -46,13 +46,24 @@
 .hero--home {
   .hero__banner {
     background-image: url('../img/fec-table-tint.png');
+    background-position: 50% 50%;
     width: 100%;
-    height: u(22rem);
+    height: u(12rem);
     position: absolute;
   }
 
   h2 {
     color: $inverse;
+    margin-bottom: u(1rem);
+  }
+
+  .hero__content {
+    padding-bottom: u(2rem);
+
+    a {
+      border-color: $inverse;
+      color: $inverse;
+    }
   }
 
   .hero__content,
@@ -61,8 +72,18 @@
   }
 
   .grid__item img {
-    width: 100%;
-    margin-bottom: u(2rem);
+    display: block;
+    margin: 0 auto (2rem) auto;
+  }
+
+  @include media($med) {
+    .grid--3-wide .grid__item {
+      @include span-columns(4);
+
+      &:nth-child(2n+1) {
+        clear: none;
+      }
+    }
   }
 
   @include media($lg) {
@@ -79,7 +100,7 @@
 
     .hero__content {
       padding-top: u(6rem);
-      padding-bottom: u(1rem);
+      padding-bottom: u(5rem);
       @include span-columns(12);
     }
 


### PR DESCRIPTION
This adjust the styles to accomodate the shorter text + new about page link in https://github.com/18F/fec-cms/pull/732/

And also makes a few fixes for improved display on medium-sized devices.

Small:

![image](https://cloud.githubusercontent.com/assets/1696495/21996079/5d34d0c4-dbdd-11e6-85b1-ed9467650283.png)

Medium:
![image](https://cloud.githubusercontent.com/assets/1696495/21996086/6563ede8-dbdd-11e6-8c13-342ce2ead5fd.png)

Large:
![image](https://cloud.githubusercontent.com/assets/1696495/21996093/6e4f4e2a-dbdd-11e6-97f0-e26f7092e890.png)
