### PR TITLE
Fixing icon size

### DIFF
--- a/scss/components/_contact-items.scss
+++ b/scss/components/_contact-items.scss
@@ -7,7 +7,7 @@
     &::before {
       content: '';
       display: block;
-      background-size: 90%;
+      background-size: 100%;
       margin-right: 2rem;
       width: u(3.4rem);
       height: u(3.4rem);
@@ -77,8 +77,8 @@
 .contact-item--hand {
   &.contact-item::before {
     @include u-icon-circle($hand-envelope, $primary, $inverse, 3.4rem);
-    background-size: 100%;
     background-position: 100% 50%;
+    background-size: 100%;
   }
 }
 


### PR DESCRIPTION
Fixes the sizes of the contact-item icons to be consistent:

![image](https://cloud.githubusercontent.com/assets/1696495/22166558/7dcd19f4-df16-11e6-963a-f995e018afe3.png)

Resolves https://github.com/18F/fec-style/issues/616