### PR TITLE
Read more link and img sizing

### DIFF
--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -21,7 +21,7 @@
 
   img {
     float: right;
-    margin-left: 2rem;
+    margin-left: u(2rem);
     height: 150px;
     width: auto;
   }

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -18,6 +18,13 @@
   h3 {
     margin-bottom: u(1rem);
   }
+
+  img {
+    float: right;
+    margin-left: 2rem;
+    height: 150px;
+    width: auto;
+  }
 }
 
 .post__pre {
@@ -37,6 +44,11 @@
     vertical-align: middle;
     margin-right: 1rem;
   }
+}
+
+.post__read-more {
+  display: inline-block;
+  margin-left: u(1rem);
 }
 
 @include media($med) {

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -47,7 +47,8 @@
 }
 
 .post__read-more {
-  display: inline-block;
+  display: inline;
+  font-weight: bold;
   margin-left: u(1rem);
 }
 


### PR DESCRIPTION
Adds margin to the read more link:
![image](https://cloud.githubusercontent.com/assets/1696495/22168447/83c6c6e2-df21-11e6-82e7-a26d7b1235ad.png)

Temporary fix for images by just resizing them if they're in a `.post`:
![image](https://cloud.githubusercontent.com/assets/1696495/22168452/8ea2096e-df21-11e6-983b-515ab00e38c2.png)
