### PR TITLE
CLASS:  .list--numbered--alt - Numbered list where child lists have bullets

### DIFF
--- a/scss/components/_list-styles.scss
+++ b/scss/components/_list-styles.scss
@@ -4,6 +4,7 @@
 //
 // .list--bulleted      - Bulleted list (for ul)
 // .list--bulleted--alt - Bulleted list where child lists don't have bullets
+// .list--numbered--alt - Numbered list where child lists have bullets
 // .list--numbered      - Numbered list (for ol)
 // .list--flat          - Lay out items horizontally
 // .list--spacious      - Adds padding above and below list items
@@ -50,6 +51,16 @@
 .list--numbered {
   li {
     list-style-type: decimal;
+  }
+}
+
+.list--numbered--alt {
+  & > li {
+    list-style-type: decimal;
+  }
+
+  ul li {
+    list-style-type: disc;
   }
 }
 


### PR DESCRIPTION
…bullets for styling needed to adhere to design mockup in https://github.com/18F/fec-style/issues/509
**Related fec-cms PR : https://github.com/18F/fec-cms/pull/756**

## Summary
Design mockup for issue https://github.com/18F/fec-style/issues/509 calls for a numbered lists with a nested bulleted list. The existing .list--numbered class cascades "list-type:decimal" down to nested children. 
I added to list-styles.scss:
**.list--numbered--alt {
  & > li {
    list-style-type: decimal;
  }

  ul li {
    list-style-type: disc;
  }
}**

This is the current convention commented at top of list-styles.scss (including new rule):
**// .list--bulleted      - Bulleted list (for ul)
// .list--bulleted--alt - Bulleted list where child lists don't have bullets
// .list--numbered--alt - Numbered list where child lists have bullets
// .list--numbered      - Numbered list (for ol)
// .list--flat          - Lay out items horizontally
// .list--spacious      - Adds padding above and below list items**
## Screenshots
I wonder if the style new rule should be called .list--numbered--disc to more logically match naming convention and coincide with later "alt" additions?

- _Update the styleguide documentation, include a screenshot if applicable._
- _Include a screenshot of the new/updated styles in context (“in the wild”)._

![list--numbered--alt](https://cloud.githubusercontent.com/assets/5572856/22191874/3887fd44-e0fd-11e6-8954-783a7e03ca0b.jpg)

_cc @username_
