### PR TITLE
Fix filter quotes

### DIFF
--- a/js/filter-typeahead.js
+++ b/js/filter-typeahead.js
@@ -19,8 +19,17 @@ function slugify(value) {
 function formatLabel(datum) {
   return datum.name ?
     datum.name + ' (' + datum.id + ')' :
-    '"' + datum.id + '"';
+    '"' + stripQuotes(datum.id) + '"';
 }
+
+function formatId(name, value) {
+  return name + '-' + slugify(value) + '-checkbox';
+}
+
+function stripQuotes(value) {
+  return value.replace(/["]+/g, '');
+}
+
 
 var textDataset = {
   display: 'id',
@@ -89,13 +98,11 @@ FilterTypeahead.prototype.setFirstItem = function() {
 };
 
 FilterTypeahead.prototype.handleSelect = function(e, datum) {
-  var id = this.fieldName + '-' + slugify(datum.id) + '-checkbox';
-
+  var id = formatId(this.fieldName, datum.id);
   this.appendCheckbox({
     name: this.fieldName,
-    label: formatLabel(datum),
     value: datum.id,
-    id: id
+    datum: datum
   });
   this.datum = null;
 
@@ -201,13 +208,26 @@ FilterTypeahead.prototype.checkboxTemplate = _.template(
 );
 
 FilterTypeahead.prototype.appendCheckbox = function(opts) {
-  if (this.$elm.find('#' + opts.id).length) {
+  var data = this.formatCheckboxData(opts);
+
+  if (this.$elm.find('#' + data.id).length) {
     return;
   }
-  var checkbox = $(this.checkboxTemplate(opts));
+  var checkbox = $(this.checkboxTemplate(data));
   checkbox.appendTo(this.$selected);
   checkbox.find('input').change();
   this.clearInput();
+};
+
+FilterTypeahead.prototype.formatCheckboxData = function(input) {
+  var output = {
+    name: input.name,
+    label: input.datum ? formatLabel(input.datum) : stripQuotes(input.value),
+    value: stripQuotes(input.value),
+    id: formatId(this.fieldName, input.value)
+  };
+
+  return output;
 };
 
 FilterTypeahead.prototype.getFilters = function(values) {
@@ -221,9 +241,8 @@ FilterTypeahead.prototype.getFilters = function(values) {
     values.forEach(function(value) {
       self.appendCheckbox({
         name: self.fieldName,
-        id: slugify(value) + '-checkbox',
-        value: value,
-        label: ID_PATTERN.test(value) ? 'Loading...' : value
+        label: ID_PATTERN.test(value) ? 'Loading...' : value,
+        value: value
       });
     });
     if (ids.length) {

--- a/js/filter-typeahead.js
+++ b/js/filter-typeahead.js
@@ -22,8 +22,8 @@ function formatLabel(datum) {
     '"' + stripQuotes(datum.id) + '"';
 }
 
-function formatId(name, value) {
-  return name + '-' + slugify(value) + '-checkbox';
+function formatId(value) {
+  return slugify(value) + '-checkbox';
 }
 
 function stripQuotes(value) {
@@ -98,7 +98,7 @@ FilterTypeahead.prototype.setFirstItem = function() {
 };
 
 FilterTypeahead.prototype.handleSelect = function(e, datum) {
-  var id = formatId(this.fieldName, datum.id);
+  var id = formatId(datum.id);
   this.appendCheckbox({
     name: this.fieldName,
     value: datum.id,
@@ -224,7 +224,7 @@ FilterTypeahead.prototype.formatCheckboxData = function(input) {
     name: input.name,
     label: input.datum ? formatLabel(input.datum) : stripQuotes(input.value),
     value: stripQuotes(input.value),
-    id: formatId(this.fieldName, input.value)
+    id: formatId(input.value)
   };
 
   return output;

--- a/js/text-filter.js
+++ b/js/text-filter.js
@@ -101,7 +101,7 @@ TextFilter.prototype.appendCheckbox = function(value) {
   var opts = {
     id: this.id + this.checkboxIndex.toString(),
     name: this.name,
-    value: value,
+    value: value.replace(/["]+/g, '')
   };
   var checkbox = $(this.checkboxTemplate(opts));
   checkbox.appendTo(this.checkboxList.$elm);

--- a/tests/text-filter.js
+++ b/tests/text-filter.js
@@ -92,6 +92,12 @@ describe('text filters', function() {
     expect(TextFilter.prototype.appendCheckboxList).to.have.not.been.called;
   });
 
+  it('strips quotes from the value', function() {
+    this.filter.appendCheckbox('"george washington"');
+    var $checkbox = this.$fixture.find('input[type="checkbox"]');
+    expect($checkbox.attr('value')).to.equal('george washington');
+  });
+
   describe('handleChange()', function() {
     it('removes the disabled class when the field has a value', function() {
       this.filter.$input.val('martha');

--- a/tests/typeahead-filter.js
+++ b/tests/typeahead-filter.js
@@ -77,7 +77,7 @@ describe('FilterTypeahead', function() {
       name: 'committee_id',
       label: 'George Washington',
       value: 'George Washington',
-      id: 'committee_id-George-Washington-checkbox'
+      id: 'George-Washington-checkbox'
     };
 
     var output = this.FilterTypeahead.formatCheckboxData(input);
@@ -98,7 +98,7 @@ describe('FilterTypeahead', function() {
       name: 'committee_id',
       label: 'Washington Committee (12345)',
       value: '12345',
-      id: 'committee_id-12345-checkbox'
+      id: '12345-checkbox'
     };
 
     var output = this.FilterTypeahead.formatCheckboxData(input);

--- a/tests/typeahead-filter.js
+++ b/tests/typeahead-filter.js
@@ -53,19 +53,56 @@ describe('FilterTypeahead', function() {
     var datum = {
       name: 'FAKE CANDIDATE',
       id: '12345',
-      office: 'Senate'
     };
     this.FilterTypeahead.handleSelect({}, datum);
 
     expect(appendCheckbox).to.have.been.calledWith({
       name: 'committee_id',
-      label: 'FAKE CANDIDATE (12345)',
       value: '12345',
-      id: 'committee_id-12345-checkbox'
+      datum: datum
     });
     expect(this.FilterTypeahead.datum).to.equal(null);
 
     this.FilterTypeahead.appendCheckbox.restore();
+  });
+
+  it('should format the data when no typeahead datum is passed in', function() {
+    var input = {
+      name: 'committee_id',
+      label: '"George Washington"',
+      value: '"George Washington"',
+    };
+
+    var expectedOutput = {
+      name: 'committee_id',
+      label: 'George Washington',
+      value: 'George Washington',
+      id: 'committee_id-George-Washington-checkbox'
+    };
+
+    var output = this.FilterTypeahead.formatCheckboxData(input);
+    expect(output).to.deep.equal(expectedOutput);
+  });
+
+  it('should format the data when a typeahead datum is passed in', function() {
+    var input = {
+      name: 'committee_id',
+      value: '12345',
+      datum: {
+        name: 'Washington Committee',
+        id: '12345'
+      }
+    };
+
+    var expectedOutput = {
+      name: 'committee_id',
+      label: 'Washington Committee (12345)',
+      value: '12345',
+      id: 'committee_id-12345-checkbox'
+    };
+
+    var output = this.FilterTypeahead.formatCheckboxData(input);
+    expect(output).to.deep.equal(expectedOutput);
   });
 
   it('should set this.datum on typeahead:autocomplte', function() {


### PR DESCRIPTION
When text and typeahead filters are generate checkboxes, they previously weren't stripping quotes out of the values, which caused the `<input type="checkbox">` to have an empty `value` attribute. This fixes that, refactors the data formatting slightly, and adds a couple tests.

I have one thing left to do on this, but need to step away and wanted to submit before I forgot.