### PR TITLE
Set z-index to make the link clickable

### DIFF
--- a/scss/modules/_hero.scss
+++ b/scss/modules/_hero.scss
@@ -59,6 +59,7 @@
 
   .hero__content {
     padding-bottom: u(2rem);
+    z-index: $z1;
 
     a {
       border-color: $inverse;


### PR DESCRIPTION
This fixes a bug where the z-indexes of the home hero were misaligned, making the "More about the FEC" link unclickable.

![image](https://cloud.githubusercontent.com/assets/1696495/22523513/8c7bad1e-e874-11e6-9706-6771c05c6884.png)

cc @xtine 