### PR TITLE
Select filter update

### DIFF
--- a/js/select-filter.js
+++ b/js/select-filter.js
@@ -19,6 +19,8 @@ SelectFilter.constructor = SelectFilter;
 
 SelectFilter.prototype.setRequiredDefault = function() {
   if (this.requiredDefault) {
+    // If there's an empty "Select an option" option, remove it
+    this.$input.find('option[value=""]').remove();
     this.setValue(this.requiredDefault);
   }
 };
@@ -28,8 +30,8 @@ SelectFilter.prototype.fromQuery = function(query) {
 };
 
 SelectFilter.prototype.setValue = function(value) {
-  this.$input.find('option[selected]').attr('selected','false');
-  this.$input.find('option[value="' + value + '"]').attr('selected','true');
+  this.$input.find('option[selected]').prop('selected', false);
+  this.$input.find('option[value="' + value + '"]').prop('selected', true);
   this.$input.change();
 };
 

--- a/tests/select-filter.js
+++ b/tests/select-filter.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+var expect = chai.expect;
+chai.use(sinonChai);
+
+var $ = require('jquery');
+
+require('./setup')();
+
+var SelectFilter = require('../js/select-filter').SelectFilter;
+
+describe('Select filter', function() {
+  before(function() {
+    this.$fixture = $('<div id="fixtures"></div>');
+    $('body').append(this.$fixture);
+  });
+
+  beforeEach(function() {
+    this.$fixture.empty().append(
+      '<div class="js-filter"' +
+        'data-filter="select"' +
+        'data-required-default="2016">' +
+        '<label class="label" for="transaction-period">Transaction period</label>' +
+        '<select name="transaction_period">' +
+            '<option value="">Select an option</option>' +
+            '<option value="2018">2018</option>' +
+            '<option value="2016">2016</option>' +
+            '<option value="2012">2012</option>' +
+        '</select>' +
+      '</div>'
+    );
+    this.filter = new SelectFilter(this.$fixture.find('.js-filter'));
+    this.trigger = sinon.spy($.prototype, 'trigger');
+  });
+
+  it('sets its initial state', function() {
+    expect(this.filter.name).to.equal('transaction_period');
+    expect(this.filter.requiredDefault).to.equal(2016);
+    expect(this.filter.$input.val()).to.equal('2016');
+  });
+
+  it('pulls values from query', function() {
+    this.filter.fromQuery({
+      transaction_period: 2018
+    });
+    expect(this.filter.$input.val()).to.equal('2018');
+  });
+
+  it('removes an empty option when setting required default', function() {
+    expect(this.filter.$input.find('option[value=""]').length === 0).to.be.true;
+  });
+
+  it('sets sets selected prop on the selected option', function() {
+    this.filter.setValue(2012);
+    expect(this.filter.$input.find('option[value="2012"]').prop('selected')).to.be.true;
+  });
+
+  afterEach(function() {
+    $.prototype.trigger.restore();
+  });
+});


### PR DESCRIPTION
This updates the `SelectFilter` component so that if a `<select>` input has an initial empty option (like `<option value="">Select an option</option>` _and_ has a required default value, once the default value is set, it removes the initial empty option. It also adds tests for this component.

Goes with https://github.com/18F/openFEC-web-app/pull/1822

cc @xtine 