### PR TITLE
Fix firefox sidenav

### DIFF
--- a/js/toc.js
+++ b/js/toc.js
@@ -56,7 +56,7 @@ TOC.prototype.scrollTo = function(e) {
   e.preventDefault();
   var $link = $(e.target);
   var section = $link.attr('href');
-  var sectionTop = $(section).offset().top;
+  var sectionTop = $(section).offset().top + 10;
   $('body, html').animate({
     scrollTop: sectionTop
   });

--- a/js/toc.js
+++ b/js/toc.js
@@ -57,7 +57,7 @@ TOC.prototype.scrollTo = function(e) {
   var $link = $(e.target);
   var section = $link.attr('href');
   var sectionTop = $(section).offset().top;
-  $(document.body).animate({
+  $('body, html').animate({
     scrollTop: sectionTop
   });
 };

--- a/scss/elements/_elements.scss
+++ b/scss/elements/_elements.scss
@@ -24,6 +24,7 @@ html {
   padding: 0;
   margin: 0;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 *, *:before, *:after {


### PR DESCRIPTION
This fixes a long-standing bug with the sticky sidenav in Firefox where clicking the links wouldn't work. Apparently Firefox can't animate the `body` element, only `html`. 

![demo](http://g.recordit.co/YFcRNNIKZ9.gif)

Second, it adjusts the scroll setting so that the correct item is highlighted at the correct point.

Third, I also added an antialiasing property to `body` so that the font-rendering is consistent with Chrome. Previously, light text on dark background looked extra bold.

Before:
![image](https://cloud.githubusercontent.com/assets/1696495/22675250/74f368b6-ec99-11e6-965c-f26057380590.png)

After:
![image](https://cloud.githubusercontent.com/assets/1696495/22675246/6f358cec-ec99-11e6-8a6d-6151ea4c4844.png)

Resolves https://github.com/18F/fec-cms/issues/280
Resolves https://github.com/18F/fec-cms/issues/244
Resolves https://github.com/18F/FEC/issues/575
Resolves https://github.com/18F/FEC/issues/586