### PR TITLE
Latest updates images

### DIFF
--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -19,6 +19,12 @@
     margin-bottom: u(1rem);
   }
 
+  // Thumbnails
+  img {
+    border: 2px solid $gray-lightest;
+    height: auto;
+  }
+
   .rich-text {
     img {
         float: right;
@@ -27,8 +33,15 @@
         width: auto;
       }
 
-    // Hide tables that might be in the body content from the scraped pages
-    table {
+    // Hide elements included in the beginning of a post other than the first paragraph
+    table,
+    ul,
+    h1,
+    h2,
+    h3,
+    h4,
+    br,
+    p:not(:first-of-type) {
       display: none;
     }
   }

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -19,11 +19,18 @@
     margin-bottom: u(1rem);
   }
 
-  img {
-    float: right;
-    margin-left: u(2rem);
-    height: 150px;
-    width: auto;
+  .rich-text {
+    img {
+        float: right;
+        margin-left: u(2rem);
+        height: 150px;
+        width: auto;
+      }
+
+    // Hide tables that might be in the body content from the scraped pages
+    table {
+      display: none;
+    }
   }
 }
 

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -27,11 +27,11 @@
 
   .rich-text {
     img {
-        float: right;
-        margin-left: u(2rem);
-        height: 150px;
-        width: auto;
-      }
+      float: right;
+      margin-left: u(2rem);
+      height: 150px;
+      width: auto;
+    }
 
     // Hide elements included in the beginning of a post other than the first paragraph
     table,

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -30,6 +30,13 @@
   td {
     @extend .simple-table__cell;
   }
+
+  img {
+    display: block;
+    clear: both;
+    float: none;
+    margin-bottom: u(2rem);
+  }
 }
 
 @media print {


### PR DESCRIPTION
This cleans up the latest updates feed by hiding any element that's not the first paragraph in the body content and adjusts the image sizing.

It also makes it so that images in rich-text fields on the actual post page aren't floated at all:

![image](https://cloud.githubusercontent.com/assets/1696495/22808655/0959ae3a-eee2-11e6-8376-abe10096832c.png)
