### PR TITLE
Changing <h6> font weight to bold

### DIFF
--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -68,7 +68,7 @@
     border-bottom: 1px solid $base;
     font-family: $sans-serif;
     font-size: u(1.3rem);
-    font-weight: normal;
+    font-weight: bold;
     line-height: 1.63;
     text-transform: uppercase;
   }


### PR DESCRIPTION
## Summary

- Makes `<h6>` font weight bold instead of regular for better visibility.

## Screenshots

<img width="1274" alt="screen shot 2017-02-10 at 1 36 54 pm" src="https://cloud.githubusercontent.com/assets/11636908/22839476/9216cf2c-ef97-11e6-895a-056d0ce2bf29.png">


Part of https://github.com/18F/fec-cms/pull/809 

