### PR TITLE
New committee pages

### DIFF
--- a/scss/components/_figures.scss
+++ b/scss/components/_figures.scss
@@ -39,3 +39,21 @@
     display: inline !important;
   }
 }
+
+.entity__figure {
+  background-color: $inverse;
+  padding: u(1rem);
+  margin-bottom: u(2rem);
+  border-radius: 2px;
+
+  .figure__label {
+    font-weight: bold;
+  }
+
+  .figure__label,
+  .figure__value {
+    font-size: u(1.6rem);
+    padding: u(.5rem);
+    vertical-align: top;
+  }
+}

--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -160,3 +160,11 @@
     height: u(1.5rem);
   }
 }
+
+// Used to create a spacer in the version column the same width as the
+// version icons
+.icon-blank {
+  display: inline-block;
+  content: '';
+  width: 20px;
+}

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -200,3 +200,59 @@ h3 + .simple-table {
     }
   }
 }
+
+// "Balance sheet" table styles
+// These provide the visual sense of nested / hierarchical rows in a balance sheet
+.level--1,
+.level--2,
+.level--3,
+.level--4 {
+  td {
+    padding: u(.5rem);
+  }
+
+  td:first-child {
+    width: 80%;
+  }
+
+  td:last-child {
+    text-align: right;
+  }
+}
+
+.level--1 {
+  background-color: $gray;
+  border-bottom: 2px solid $inverse;
+  text-transform: uppercase;
+  font-weight: bold;
+}
+
+.level--2 {
+  background-color: $gray-light;
+  border: 1px solid $gray-medium;
+  font-weight: bold;
+  text-transform: uppercase;
+
+  td:first-child {
+    border-right: 1px solid $gray;
+  }
+}
+
+.level--3 {
+  td:first-child {
+    border-right: 1px solid $gray;
+    padding-left: u(2rem);
+  }
+
+  & + .level--2 {
+    border-bottom: 1px solid $gray-medium;
+  }
+}
+
+.level--4 {
+  td:first-child {
+    border-right: 1px solid $gray;
+    padding-left: u(4rem);
+    font-style: italic;
+  }
+}

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -207,6 +207,8 @@ h3 + .simple-table {
 .level--2,
 .level--3,
 .level--4 {
+  border-collapse: separate;
+
   td {
     padding: u(.5rem);
   }
@@ -234,24 +236,22 @@ h3 + .simple-table {
   text-transform: uppercase;
 
   td:first-child {
-    border-right: 1px solid $gray;
+    border-right: 1px solid $gray-medium;
   }
 }
 
 .level--3 {
-  td:first-child {
-    border-right: 1px solid $gray;
-    padding-left: u(2rem);
-  }
+  border-bottom: 1px solid $gray-medium;
 
-  & + .level--2 {
-    border-bottom: 1px solid $gray-medium;
+  td:first-child {
+    border-right: 1px solid $gray-medium;
+    padding-left: u(2rem);
   }
 }
 
 .level--4 {
   td:first-child {
-    border-right: 1px solid $gray;
+    border-right: 1px solid $gray-medium;
     padding-left: u(4rem);
     font-style: italic;
   }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -188,6 +188,19 @@
   }
 }
 
+.data-table--entity {
+  border-top: 2px solid $primary;
+
+  td {
+    padding: u(.5rem);
+    vertical-align: middle;
+  }
+
+  .document-description {
+    vertical-align: middle;
+  }
+}
+
 
 // Special styles for rows that trigger panels
 .row--has-panel {
@@ -316,6 +329,10 @@
 @include media($med) {
   .column--state {
     width: 50px;
+  }
+
+  .column--xs {
+    width: 40px;
   }
 
   .column--small {


### PR DESCRIPTION
This adds a few new styles for the new candidate and committee pages. 

First, there's styles for the financial summary component. To get this effect, a `level--*` class is applied to the `<tr>`:
![image](https://cloud.githubusercontent.com/assets/1696495/22850571/8a045b6e-efc0-11e6-8eb2-9297a65dffaf.png)

It also includes styles for this pattern:
![image](https://cloud.githubusercontent.com/assets/1696495/22850577/9861511c-efc0-11e6-88de-3ec25685716d.png)

And some new tweaked styles for datatables on these pages:
![image](https://cloud.githubusercontent.com/assets/1696495/22850579/a9ba0e90-efc0-11e6-977c-1f1d74e43495.png)
