### PR TITLE
Mitigate XSS and content spoofing attacks

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -2,8 +2,10 @@
 
 /* global ga */
 
-var URI = require('urijs');
 var _ = require('underscore');
+var URI = require('urijs');
+
+var helpers = require('./helpers');
 
 function trackerExists() {
   if (typeof ga !== 'undefined') {
@@ -31,7 +33,7 @@ function pageView() {
   if (typeof ga === 'undefined') { return; }
   var path = document.location.pathname;
   if (document.location.search) {
-    var query = URI.parseQuery(document.location.search);
+    var query = helpers.sanitizeQueryParams(URI.parseQuery(document.location.search));
     path += '?' + sortQuery(query);
   }
   ga('notDAP.send', 'pageview', path);

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -4,6 +4,7 @@ var $ = require('jquery');
 var _ = require('underscore');
 var URI = require('urijs');
 
+var helpers = require('./helpers');
 var TextFilter = require('./text-filter').TextFilter;
 var CheckboxFilter = require('./checkbox-filter').CheckboxFilter;
 var MultiFilter = require('./multi-filter').MultiFilter;
@@ -48,7 +49,7 @@ FilterSet.prototype.buildFilter = function($elm) {
 
 FilterSet.prototype.activate = function($selector) {
   var self = this;
-  var query = URI.parseQuery(window.location.search);
+  var query = helpers.sanitizeQueryParams(URI.parseQuery(window.location.search));
   var filters = _.chain($selector)
     .map(function(elm) {
       var filter = self.buildFilter($(elm)); // .fromQuery(query);
@@ -156,7 +157,7 @@ FilterSet.prototype.switchFilters = function(dataType) {
 
 FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   // Save the current query for later
-  var query = URI.parseQuery(window.location.search);
+  var query = helpers.sanitizeQueryParams(URI.parseQuery(window.location.search));
   // Clear filters if this isn't the first page load
   // Set forceRemove: true to clear date filters that are usually nonremovable
   if (!this.firstLoad) {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* global require, module */
-
+var _ = require('underscore');
 var bleach = require('bleach');
 var moment = require('moment');
 var Handlebars = require('hbsfy/runtime');
@@ -58,9 +58,14 @@ function sanitizeValue(value) {
   var validCharactersRegEx = /[^a-z0-9-',.()\s]/ig;
 
   if (value !== null || value !== undefined) {
-    if ($.isArray(value)) {
+    if (_.isArray(value)) {
       for (var i = 0; i < value.length; i++) {
-        value[i] = bleach.sanitize(value[i]).replace(validCharactersRegEx, '');
+        if (value[i] !== null || value[i] !== undefined) {
+          value[i] = bleach.sanitize(value[i]).replace(
+            validCharactersRegEx,
+            ''
+          );
+        }
       }
     } else {
       value = bleach.sanitize(value).replace(validCharactersRegEx, '');

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -57,10 +57,10 @@ function datetime(value, options) {
 function sanitizeValue(value) {
   var validCharactersRegEx = /[^a-z0-9-',.()\s]/ig;
 
-  if (value !== null || value !== undefined) {
+  if (value !== null && value !== undefined) {
     if (_.isArray(value)) {
       for (var i = 0; i < value.length; i++) {
-        if (value[i] !== null || value[i] !== undefined) {
+        if (value[i] !== null && value[i] !== undefined) {
           value[i] = bleach.sanitize(value[i]).replace(
             validCharactersRegEx,
             ''

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -2,6 +2,7 @@
 
 /* global require, module */
 
+var bleach = require('bleach');
 var moment = require('moment');
 var Handlebars = require('hbsfy/runtime');
 
@@ -51,6 +52,37 @@ function datetime(value, options) {
   return parsed.isValid() ? parsed.format(format) : null;
 }
 
+// Sanitizes a single value by removing HTML tags and whitelisting valid
+// characters.
+function sanitizeValue(value) {
+  var validCharactersRegEx = /[^a-z0-9-',.()\s]/ig;
+
+  if (value !== null || value !== undefined) {
+    if ($.isArray(value)) {
+      for (var i = 0; i < value.length; i++) {
+        value[i] = bleach.sanitize(value[i]).replace(validCharactersRegEx, '');
+      }
+    } else {
+      value = bleach.sanitize(value).replace(validCharactersRegEx, '');
+    }
+  }
+
+  return value;
+}
+
+// Sanitizes all parameters retrieved from the query string in the URL.
+function sanitizeQueryParams(query) {
+  var param;
+
+  for (param in query) {
+    if (query.hasOwnProperty(param)) {
+      query[param] = sanitizeValue(query[param]);
+    }
+  }
+
+  return query;
+}
+
 Handlebars.registerHelper('datetime', datetime);
 
 Handlebars.registerHelper({
@@ -70,5 +102,7 @@ module.exports = {
   getWindowWidth: getWindowWidth,
   helpers: Handlebars.helpers,
   LOADING_DELAY: LOADING_DELAY,
-  SUCCESS_DELAY: SUCCESS_DELAY
+  SUCCESS_DELAY: SUCCESS_DELAY,
+  sanitizeValue: sanitizeValue,
+  sanitizeQueryParams: sanitizeQueryParams
 };

--- a/js/urls.js
+++ b/js/urls.js
@@ -1,9 +1,11 @@
 'use strict';
 
-var URI = require('urijs');
+var $ = require('jquery');
 var _ = require('underscore');
+var URI = require('urijs');
 
 var analytics = require('./analytics');
+var helpers = require('./helpers');
 
 function updateQuery(params, fields) {
   var queryString = nextUrl(params, fields);
@@ -22,7 +24,7 @@ function pushQuery(params, fields) {
 }
 
 function nextUrl(params, fields) {
-  var query = URI.parseQuery(window.location.search);
+  var query = helpers.sanitizeQueryParams(URI.parseQuery(window.location.search));
   if (!compareQuery(query, params, fields)) {
     // Clear and update filter fields
     _.each(fields, function(field) {

--- a/js/urls.js
+++ b/js/urls.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var $ = require('jquery');
 var _ = require('underscore');
 var URI = require('urijs');
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "accessible-mega-menu": "git+https://github.com/noahmanger/Accessible-Mega-Menu.git",
     "aria-accordion": "0.1.1",
+    "bleach": "0.3.0",
     "glossary-panel": "0.1.2",
     "eventemitter2": "0.4.14",
     "jquery": "2.1.4",

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -56,6 +56,7 @@ describe('helpers', function() {
         max_date: '12-31-2016',
         min_date: '01-01-2015',
         support_oppose_indicator: 'S',
+        sort: '@#$(@#8923012;,/.as><AJKO@&amp;&#41;',
         q: '@@@@@@@@@@@@@@@@@@@@@@'
       };
 
@@ -65,6 +66,7 @@ describe('helpers', function() {
         max_date: '12-31-2016',
         min_date: '01-01-2015',
         support_oppose_indicator: 'S',
+        sort: '(8923012,.asAJKOamp41',
         q: ''
       });
     });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -31,7 +31,7 @@ describe('helpers', function() {
     });
 
     it('skips sanitizing undefined values', function() {
-      var value = undefined;
+      var value;
 
       expect(helpers.sanitizeValue(value)).to.be.undefined;
     });
@@ -67,6 +67,6 @@ describe('helpers', function() {
         support_oppose_indicator: 'S',
         q: ''
       });
-    })
+    });
   });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+
+var helpers = require('../js/helpers');
+
+describe('helpers', function() {
+  describe('sanitizeValue', function() {
+    it('sanitizes a string', function() {
+      var value = 'X0YZ12345><sCrIPt>alert(document.cookie)</ScRiPt>';
+
+      expect(helpers.sanitizeValue(value)).to.equal('X0YZ12345');
+    });
+
+    it('sanitizes an array', function() {
+      var value = [
+          'X0YZ12345><sCrIPt>alert(document.cookie)</ScRiPt>',
+          'A1BC67890'
+      ];
+
+      expect(helpers.sanitizeValue(value)).to.deep.equal(
+          ['X0YZ12345', 'A1BC67890']
+      );
+    });
+
+    it('skips sanitizing null values', function() {
+      var value = null;
+
+      expect(helpers.sanitizeValue(value)).to.be.null;
+    });
+
+    it('skips sanitizing undefined values', function() {
+      var value = undefined;
+
+      expect(helpers.sanitizeValue(value)).to.be.undefined;
+    });
+
+    it('sanitizes an array that includes null values', function() {
+      var value = [
+          'X0YZ12345"><sCrIPt>alert(document.cookie)</ScRiPt>',
+          null
+      ];
+
+      expect(helpers.sanitizeValue(value)).to.deep.equal(
+          ['X0YZ12345', null]
+      );
+    });
+  });
+
+  describe('sanitizeQueryParams', function() {
+    it('sanitizes a collection of parameters', function() {
+      var query = {
+        candidate_id: 'H4GA06087"><sCrIPt>alert(document.cookie)</ScRiPt>',
+        committee_id: 'C00509893',
+        max_date: '12-31-2016',
+        min_date: '01-01-2015',
+        support_oppose_indicator: 'S',
+        q: '@@@@@@@@@@@@@@@@@@@@@@'
+      };
+
+      expect(helpers.sanitizeQueryParams(query)).to.deep.equal({
+        candidate_id: 'H4GA06087',
+        committee_id: 'C00509893',
+        max_date: '12-31-2016',
+        min_date: '01-01-2015',
+        support_oppose_indicator: 'S',
+        q: ''
+      });
+    })
+  });
+});


### PR DESCRIPTION
Addresses #633

This changeset adds support to mitigate potential XSS and content spoofing attacks through our client-side code.  Penetration testing has yielded a few spots in our code where we were accepting values as is when pulling them from the query string in the URL, mainly when pre-initializing filters.  We have addressed this by making use of the `bleach` (https://github.com/ecto/bleach) library to strip all tags from this content, and then stripping out all other characters not whitelisted as being valid.  We determined that only certain characters should be allowed for the filter values and feel safe in ignoring all others.

A huge thank you to @xtine for pairing with me on this and helping solve the issue!  h/t to @LinuxBozo, @toolness, and @cmc333333 for the additional help!