### PR TITLE
Typography improvements

### DIFF
--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -194,6 +194,7 @@
 // Stacked cards, when there's more than one in a vertical column
 .card--stacked {
   margin-top: u(2rem);
+  margin-bottom: u(1rem);
 }
 
 // For lists of links, such as on data landing page cards

--- a/scss/components/_list-styles.scss
+++ b/scss/components/_list-styles.scss
@@ -94,7 +94,7 @@
   }
 
   li {
-    padding: u(1rem 0);
+    padding: u(.75rem 0);
   }
 }
 

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -16,7 +16,7 @@
   }
 
   h3 {
-    margin-bottom: u(0.4rem);
+    margin-bottom: u(.4rem);
   }
 
   p {

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -19,6 +19,10 @@
     margin-bottom: u(1rem);
   }
 
+  p {
+    margin: u(0 0 1rem 0);
+  }
+
   // Thumbnails
   img {
     border: 2px solid $gray-lightest;

--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -16,7 +16,7 @@
   }
 
   h3 {
-    margin-bottom: u(1rem);
+    margin-bottom: u(0.4rem);
   }
 
   p {

--- a/scss/components/_side-nav.scss
+++ b/scss/components/_side-nav.scss
@@ -47,6 +47,7 @@
   font-family: $sans-serif;
   padding: 4px;
   text-transform: uppercase;
+  line-height: 2rem;
 
   &:hover,
   &.is-active {

--- a/scss/components/_side-nav.scss
+++ b/scss/components/_side-nav.scss
@@ -47,7 +47,7 @@
   font-family: $sans-serif;
   padding: 4px;
   text-transform: uppercase;
-  line-height: 2rem;
+  line-height: u(2rem);
 
   &:hover,
   &.is-active {

--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -21,7 +21,7 @@ body {
   color: $base;
   font-family: $base-font-family;
   font-size: u(1.4rem);
-  line-height: 1.5;
+  line-height: 1.8;
 }
 
 h1 {
@@ -51,7 +51,7 @@ h6 {
 p {
   color: inherit;
   font-size: u(1.6rem);
-  margin: u(0 0 1rem 0);
+  margin: u(0 0 2.6rem 0);
   max-width: u(80rem);
   width: 100%;
 
@@ -79,6 +79,3 @@ hr {
   border-top: none;
   margin: u(1rem 0);
 }
-
-
-

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -49,10 +49,10 @@
   @if $level == h4 {
     font-family: $sans-serif;
     font-size: u(1.8rem);
-    font-weight: normal;
+    font-weight: bold;
     line-height: 1.2;
     letter-spacing: -.3px;
-    margin: 0;
+    margin: u(1.4rem 0 1rem 0);
   }
 
   @if $level == h5 {

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -43,7 +43,7 @@
     font-family: $serif;
     font-size: u(1.8rem);
     font-weight: bold;
-    line-height: 1.14;
+    line-height: 1.6;
   }
 
   @if $level == h4 {

--- a/scss/mixins/_type-mixins.scss
+++ b/scss/mixins/_type-mixins.scss
@@ -20,12 +20,11 @@
     font-family: $serif;
     font-size: u(2.4rem);
     font-weight: bold;
-    line-height: 1.15;
+    line-height: 1.2;
     margin: 0;
 
     @include media($med) {
       font-size: u(3.6rem);
-      line-height: 1.2;
     }
   }
 


### PR DESCRIPTION
## Summary

Revisits typography elements with a focus on spacing and styling for clarity: the big goal was to make it easier to tell headline classes apart in text-heavy articles, such as Weekly updates, the e-filing report, and other CMS content-based pages. To accomplish this, I looked mainly at space above/below text elements.


## Screenshots

I was having trouble running the cms today, so I don't have any screenshots of that side, but I vetted it closely as I was making the changes to those pages last week. Here are shots of the data side where changes applied:

**Change in h4 style & h3+p spacing** 
<img width="1084" alt="screen shot 2017-02-27 at 9 37 29 am" src="https://cloud.githubusercontent.com/assets/11636908/23366372/6611f952-fcd4-11e6-9e98-63b65ab3ebde.png">

**Reduction in spacious list item spacing**
<img width="499" alt="screen shot 2017-02-27 at 9 43 03 am" src="https://cloud.githubusercontent.com/assets/11636908/23366385/7b2d2884-fcd4-11e6-80a9-062e1f770f77.png">

**Increase space between icon and text**
<img width="169" alt="screen shot 2017-02-27 at 9 46 21 am" src="https://cloud.githubusercontent.com/assets/11636908/23366394/87e9622c-fcd4-11e6-87e5-9528dfa7d6df.png">



cc @noahmanger @xtine 
