### PR TITLE
Richtext images

### DIFF
--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -29,7 +29,13 @@
     height: auto;
   }
 
+  .richtext-image {
+    // Hides images that have been inserted in the richtext editor
+    display: none;
+  }
+
   .rich-text {
+    // This floats images that are included in the body by virtue of being scraped and imported
     img {
       float: right;
       margin-left: u(2rem);

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -39,6 +39,16 @@
   }
 }
 
+.richtext-image {
+  &.right {
+    float: right;
+  }
+
+  &.left {
+    float: left;
+  }
+}
+
 @media print {
   .rich-text table,
   .block-table table {

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -39,13 +39,19 @@
   }
 }
 
-.richtext-image {
-  &.right {
-    float: right;
-  }
+@include media($lg) {
+  .richtext-image {
+    &.right {
+      float: right;
+      margin-left: u(5rem);
+      margin-bottom: u(4rem);
+    }
 
-  &.left {
-    float: left;
+    &.left {
+      float: left;
+      margin-right: u(5rem);
+      margin-bottom: u(4rem);
+    }
   }
 }
 


### PR DESCRIPTION
This adds styles for the classes Wagtail adds when inserting images in the rich text editor so that they will float alongside text like:

![image](https://cloud.githubusercontent.com/assets/1696495/23491908/2690a0b0-feb6-11e6-8e18-3603de13c1b1.png)

Resolves a thread from Slack. 