### PR TITLE
removed unnecessary font size

### DIFF
--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -83,7 +83,6 @@ hr {
 blockquote {
   border-left: 10px solid $gray-lightest;
   padding-left: 30px;
-  font-size: u(1.6rem);
   font-style: italic;
   margin-left: 0;
 }


### PR DESCRIPTION
Updated fec-cms PR https://github.com/18F/fec-cms/pull/861. Font size now inherits from <p> tag.