### PR TITLE
orange document icon for homepage

### DIFF
--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -286,7 +286,7 @@
     &.i-document {
       @include u-icon-bg($document, $secondary-contrast);
       background-position: 50% 50%;
-      background-size: 60%;
+      background-size: 50%;
     }
 
     &.i-info-person {

--- a/scss/components/_cards.scss
+++ b/scss/components/_cards.scss
@@ -283,6 +283,12 @@
       background-size: 60%;
     }
 
+    &.i-document {
+      @include u-icon-bg($document, $secondary-contrast);
+      background-position: 50% 50%;
+      background-size: 60%;
+    }
+
     &.i-info-person {
       @include u-icon-bg($info-person, $secondary-contrast);
       background-position: 50% 110%;

--- a/scss/components/_icon-headings.scss
+++ b/scss/components/_icon-headings.scss
@@ -189,7 +189,6 @@
   }
 }
 
-
 // icons for homepage - legal resources (on primary [blue] slab)
 .icon-heading--mallet-circle {
   &::before {


### PR DESCRIPTION
Makes an orange specific icon for homepage secondary card.

<img width="236" alt="screen shot 2017-03-22 at 5 51 05 pm" src="https://cloud.githubusercontent.com/assets/24054/24225806/2a3005ee-0f28-11e7-8e19-820d2c24f3a8.png">

Supports https://github.com/18F/fec-cms/pull/903