### PR TITLE
Flexbox class for grids

### DIFF
--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -40,6 +40,15 @@
   @include outer-container;
 }
 
+// flexbox for full height cards
+.grid--flex {
+  display: flex;
+
+  .grid__item {
+    display: flex !important;
+  }
+}
+
 .grid__item {
   margin-bottom: u(2rem);
   width: 100%;


### PR DESCRIPTION
This sets a `.grid--flex` class for enabling flexbox for grids, this will allow cards to inherit full heights:

<img width="965" alt="screen shot 2017-03-22 at 12 15 48 pm" src="https://cloud.githubusercontent.com/assets/24054/24214020/dad872a2-0ef9-11e7-9772-3d30e24539be.png">
