### PR TITLE
Responsive flexbox grid items

### DIFF
--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -42,6 +42,7 @@
 
 // flexbox for full height cards
 .grid--flex {
+  flex-wrap: wrap;
   display: flex;
 
   .grid__item {


### PR DESCRIPTION
Adds `flex-wrap: wrap` for responsive behavior for flexboxy grid items.
<img width="559" alt="screen shot 2017-03-22 at 6 04 36 pm" src="https://cloud.githubusercontent.com/assets/24054/24226106/2f1021fa-0f2a-11e7-93ba-b0889ac7c58e.png">
