### PR TITLE
Critical dependency fix: updating jQuery to latest 2.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bleach": "0.3.0",
     "glossary-panel": "0.1.2",
     "eventemitter2": "0.4.14",
-    "jquery": "2.1.4",
+    "jquery": "2.2.4",
     "jquery.inputmask": "3.2.7",
     "moment": "2.10.3",
     "node-bourbon": "4.2.2",


### PR DESCRIPTION
We just received notice this morning of a security vulnerability in our pinned version of jQuery.  This changeset addresses that by pinning the latest 2.x release (2.2.4 at this time).