### PR TITLE
Fix issue related to jQuery version bump

### DIFF
--- a/js/toc.js
+++ b/js/toc.js
@@ -36,7 +36,7 @@ TOC.prototype.addWatchers = function() {
   return this.sections.map(function(idx, section) {
     var elm = document.querySelector(section);
     var watcher = scrollMonitor.create(elm, {top: self.offset});
-    watcher.$menuItem = self.$menu.find('a[href=' + section + ']');
+    watcher.$menuItem = self.$menu.find('a[href="' + section + '"]');
     watcher.enterViewport(function() {
       self.highlightActiveItem(this);
     });


### PR DESCRIPTION
The update to jQuery caused a regression to appear with one of our selectors, though the selector itself was not set up quite right.  This changeset fixes the issue by adding quotes around the value for the `a[ref="<value>"]` selector.  Please see the comments section of the version 1.12 and 2.2 release notes for details: http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/