### PR TITLE
Removing paragraph spacing in lists and .messages

### DIFF
--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -100,18 +100,9 @@
   }
 }
 
-.pending-ao__title a {
-  position: relative;
-
-  &::after {
-    @include u-icon-bg($timer, $base);
-    background-size: 90%;
-    background-position: 0 50%;
-    display: inline-block;
-    content: '';
-    width: 1em;
-    height: 1em;
-    position: absolute;
-    right: -2.5rem;
-  }
+.pending-ao__title {
+  @include u-icon-bg($timer, $base);
+  display: inline-block;
+  padding-right: 2.5rem;
+  background-position: 100% 50%;
 }

--- a/scss/components/_legal-search.scss
+++ b/scss/components/_legal-search.scss
@@ -103,6 +103,6 @@
 .pending-ao__title {
   @include u-icon-bg($timer, $base);
   display: inline-block;
-  padding-right: 2.5rem;
+  padding-right: u(2.5rem);
   background-position: 100% 50%;
 }

--- a/scss/components/_messages.scss
+++ b/scss/components/_messages.scss
@@ -22,6 +22,10 @@
   border-width: 0 0 0 3px;
   margin: u(2rem 0);
   padding: u(5rem 2rem 2rem 2rem);
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .message--success {

--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -40,3 +40,10 @@ dl {
     margin: 0;
   }
 }
+
+// When <p>s are inside <li>s, they shouldn't have bottom margin.
+// Only targetting the last-child in case there's a situation with multiple <p>
+// in which case every one but the last should have margin-bottom.
+li p:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Sometimes `<p>` tags get nested inside `<li>`s. When that's the case, they shouldn't have bottom margin (unless they're one of multiple, in which case, only the last one shouldn't have it). 

Also if they're inside `.messages` they shouldn't have it either.

Incorrect:
![image](https://cloud.githubusercontent.com/assets/1696495/24530623/0e13eb5a-1568-11e7-9ebb-56db36552724.png)

Correct:
![image](https://cloud.githubusercontent.com/assets/1696495/24530619/03aabcca-1568-11e7-96d1-875ec3fd523f.png)
