### PR TITLE
Add dataType to ajax request

### DIFF
--- a/js/feedback.js
+++ b/js/feedback.js
@@ -74,7 +74,8 @@ Feedback.prototype.submit = function(e) {
     method: 'POST',
     url: this.url,
     data: JSON.stringify(data),
-    contentType: 'application/json'
+    contentType: 'application/json',
+    dataType: 'json'
   });
   promise.done(this.handleSuccess.bind(this));
   promise.fail(this.handleError.bind(this));


### PR DESCRIPTION
This changeset addresses the jQuery vulnerability we encountered a bit further by ensuring that a dataType parameter is set on our ajax requests.  We cannot do an upgrade to the 3.x series of jQuery just yet, so to help mitigate any potential threat we are ensuring our requests do not accept scripts to be executed.  We will update jQuery to the latest release in the near future after we have had a bit more time to test the changes and address any compatibility issues.