### PR TITLE
Adding styles for dense tables

### DIFF
--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -319,3 +319,39 @@ h3 + .simple-table {
     margin-bottom: u(1rem);
   }
 }
+
+// Dense table
+// For tables with a lot of data that need to be condensed
+.dense-table {
+  table-layout: auto;
+  border-top: none;
+  border-bottom-width: 0;
+
+  td,
+  th {
+    border-bottom: 1px solid $gray-light;
+    border-right: 1px solid $gray-light;
+    font-size: u(1.2rem);
+    line-height: 1.2;
+    padding: u(.5rem);
+    vertical-align: middle;
+    word-wrap: break-word;
+  }
+
+  thead th {
+    border-bottom: 1px solid $primary;
+  }
+
+  tbody th {
+    border-right: 1px solid $primary;
+  }
+
+  th[scope="colgroup"],
+  th[scope="rowgroup"] {
+    text-align: center;
+    background-color: $primary;
+    color: $inverse;
+    border-bottom: none;
+    border-right: none;
+  }
+}


### PR DESCRIPTION
Adds custom styles for the occasion when you need an information dense table with `colgroup` and `rowgroup` headers like:

![image](https://cloud.githubusercontent.com/assets/1696495/24633243/5814a822-187c-11e7-904b-4ee642adf785.png)
 