### PR TITLE
Financial summary table style cleanup

### DIFF
--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -213,12 +213,14 @@ h3 + .simple-table {
     padding: u(.5rem);
   }
 
-  td:first-child {
-    width: 80%;
-  }
-
   td:last-child {
     text-align: right;
+  }
+
+  @include media($lg) {
+    td:first-child {
+      width: 80%;
+    }
   }
 }
 
@@ -250,10 +252,11 @@ h3 + .simple-table {
 }
 
 .level--4 {
+  font-style: italic;
+
   td:first-child {
     border-right: 1px solid $gray-medium;
     padding-left: u(4rem);
-    font-style: italic;
   }
 }
 


### PR DESCRIPTION
- Only sets the table-cell width on large screens, to prevent the table from overflowing boundaries on small screens
- Italicizes fourth-level numbers (resolves https://github.com/18F/openFEC-web-app/issues/1862)

![image](https://cloud.githubusercontent.com/assets/1696495/24636905/45c914b2-1892-11e7-83a2-f06280be3520.png)

