### PR TITLE
Removing link to RAD contact page

### DIFF
--- a/js/templates/nav-help.hbs
+++ b/js/templates/nav-help.hbs
@@ -15,7 +15,6 @@
         </ul>
         <ul class="usa-width-one-third mega__list">
           <li><a class="mega__page-link" href="{{transitionUrl}}/info/outreach.shtml">Trainings</a></li>
-          <li><a class="mega__page-link" href="{{cmsUrl}}/help-candidates-and-committees/question-rad">Submit a question</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
The RAD contact form isn't ready yet, so this removes the link from the nav for now.

![image](https://cloud.githubusercontent.com/assets/1696495/24690051/682fcfd0-197f-11e7-82e3-0e7404394276.png)

@jenniferthibault does this work for you? Or should we just have a single column of three links?