### PR TITLE
Fix filter height

### DIFF
--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -10,7 +10,6 @@ var helpers = require('./helpers');
 var defaultOptions = {
   body: '.filters',
   content: '.filters__content',
-  dataContainer: '.data-container',
   filterHeader: '.js-filter-header',
   form: '#category-filters',
   focus: '.js-filter-toggle',
@@ -23,7 +22,6 @@ function FilterPanel(options) {
 
   this.$body = $(this.options.body);
   this.$content = this.$body.find(this.options.content);
-  this.$dataContainer = $(this.options.dataContainer);
   this.$form = $(this.options.form);
   this.$focus = $(this.options.focus);
   this.$toggle = $(this.options.toggle);

--- a/js/filter-panel.js
+++ b/js/filter-panel.js
@@ -48,8 +48,7 @@ FilterPanel.prototype.setInitialDisplay = function() {
 
 FilterPanel.prototype.show = function(focus) {
   if (!helpers.isLargeScreen()) {
-    var top = this.$toggle.outerHeight() +  this.$toggle.position().top;
-    this.$content.css('top', top);
+    this.$content.css('top', 0);
   }
   this.$body.addClass('is-open');
   this.$content.attr('aria-hidden', false);
@@ -64,6 +63,10 @@ FilterPanel.prototype.show = function(focus) {
 };
 
 FilterPanel.prototype.hide = function() {
+  if (!helpers.isLargeScreen()) {
+    var top = this.$toggle.outerHeight() +  this.$toggle.position().top;
+    this.$content.css('top', top);
+  }
   this.$body.removeClass('is-open');
   this.$content.attr('aria-hidden', true);
   this.$focus.focus();

--- a/scss/modules/_filters.scss
+++ b/scss/modules/_filters.scss
@@ -32,6 +32,7 @@ $filter-button-width: u(4.6rem);
   &.is-open {
     .filters__content {
       left: 0;
+      position: relative;
     }
 
     // For long filter titles, wrap them in a class to force icons to line up


### PR DESCRIPTION
This fixes the issue on small screens where if the results are shorter than the filter panel, the panel would overflow. 

This fixes it by instead making the panel `position: relative` when opened, and `position: absolute` when closed. In the js, it sets the top to 0 when open and the top to the necessary height when closed so it doesn't flicker up the screen when the position changes.

Resolves https://github.com/18F/fec-style/issues/657