### PR TITLE
Site tour updates

### DIFF
--- a/js/site-orientation.js
+++ b/js/site-orientation.js
@@ -25,11 +25,13 @@ function SiteOrientation(selector) {
   this.$startTourLink = this.$selector.find('.tour__start__button');
   this.$startTourLink.on('click', this.startTour.bind(this));
 
-  if (uriQuery.tour) {
-    this.startTour();
-  }
-  else {
-    this.initBanner();
+  if (this.$selector.length) {
+    if (uriQuery.tour) {
+      this.startTour();
+    }
+    else {
+      this.initBanner();
+    }
   }
 }
 

--- a/js/site-orientation.js
+++ b/js/site-orientation.js
@@ -130,7 +130,7 @@ SiteOrientation.prototype.startTour = function () {
   this.setupTourHeader();
   this.setupTourPoints();
 
-  if (TOUR_PAGE === this.lastTourPage) {
+  if (TOUR_PAGE === lastTourPage) {
     // Last tooltip (tour.onexit) opens modal
     tourLastLabel = 'Next <i class="icon icon--small i-arrow-right"></i>';
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-style",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Shared styles for FEC Beta",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- The finishing tour button that triggers end modal should be "Next" instead of "Next section"
- Prevents tour from starting if banner is not present (on auto tour urls like http://127.0.0.1:8000/?tour=true)

<img width="933" alt="screen shot 2017-04-19 at 1 34 19 pm" src="https://cloud.githubusercontent.com/assets/24054/25198525/0f1c87da-2505-11e7-92ac-211ec034f125.png">
