### PR TITLE
Removing "No results" messages on typeahead

### DIFF
--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -85,7 +85,7 @@ var candidateDataset = {
     header: '<span class="tt-suggestion__header">Select a candidate:</span>',
     pending: '<span class="tt-suggestion__loading">Loading suggestions...</span>',
     notFound: Handlebars.compile(
-      '<span class="tt-suggestion__header tt-suggestion__missing">No candidates found matching "{{query}}"</span>'
+      '<span></span>'
     ),
     suggestion: Handlebars.compile(
       '<span>' +
@@ -105,7 +105,7 @@ var committeeDataset = {
     header: '<span class="tt-suggestion__header">Select a committee:</span>',
     pending: '<span class="tt-suggestion__loading">Loading suggestions...</span>',
     notFound: Handlebars.compile(
-      '<span class="tt-suggestion__header tt-suggestion__missing">No committees found matching "{{query}}"</span>'
+      '<span></span>'
     ),
     suggestion: Handlebars.compile(
       '<span class="tt-suggestion__name">{{ name }} ({{ id }})</span>'
@@ -145,7 +145,7 @@ var siteDataset = {
   },
   templates: {
     suggestion: function(datum) {
-      return '<span><strong>Search everything else:</strong> "' + datum.id + '"</span>';
+      return '<span><strong>Search other pages:</strong> "' + datum.id + '"</span>';
     }
   }
 };

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -83,7 +83,7 @@ var candidateDataset = {
   source: candidateEngine,
   templates: {
     header: '<span class="tt-suggestion__header">Select a candidate:</span>',
-    pending: '<span class="tt-suggestion__loading">Loading suggestions...</span>',
+    pending: '<span class="tt-suggestion__loading">Loading candidates...</span>',
     notFound: Handlebars.compile(
       '<span></span>'
     ),
@@ -103,7 +103,7 @@ var committeeDataset = {
   source: committeeEngine,
   templates: {
     header: '<span class="tt-suggestion__header">Select a committee:</span>',
-    pending: '<span class="tt-suggestion__loading">Loading suggestions...</span>',
+    pending: '<span class="tt-suggestion__loading">Loading committees...</span>',
     notFound: Handlebars.compile(
       '<span></span>'
     ),

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -140,7 +140,7 @@ var siteDataset = {
   source: function(query, syncResults) {
     syncResults([{
       id: query,
-      type: 'digitalgov'
+      type: 'site'
     }]);
   },
   templates: {

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -84,9 +84,7 @@ var candidateDataset = {
   templates: {
     header: '<span class="tt-suggestion__header">Select a candidate:</span>',
     pending: '<span class="tt-suggestion__loading">Loading candidates...</span>',
-    notFound: Handlebars.compile(
-      '<span></span>'
-    ),
+    notFound: Handlebars.compile(''), // This has to be empty to not show anything
     suggestion: Handlebars.compile(
       '<span>' +
       '<span class="tt-suggestion__name">{{ name }} ({{ id }})</span>' +
@@ -104,9 +102,7 @@ var committeeDataset = {
   templates: {
     header: '<span class="tt-suggestion__header">Select a committee:</span>',
     pending: '<span class="tt-suggestion__loading">Loading committees...</span>',
-    notFound: Handlebars.compile(
-      '<span></span>'
-    ),
+    notFound: Handlebars.compile(''), // This has to be empty to not show anything
     suggestion: Handlebars.compile(
       '<span class="tt-suggestion__name">{{ name }} ({{ id }})</span>'
     )


### PR DESCRIPTION
This removes the "No matching candidates/committees" boxes on typeaheads when there's no results. As discussed in Slack, this makes more sense because there are still possibly results if you search and we don't want to throw a seeming error message if it's not actually a dead end. See:

![image](http://g.recordit.co/HKQhLRdayF.gif)