### PR TITLE
Contact form fixes

### DIFF
--- a/js/templates/nav-help.hbs
+++ b/js/templates/nav-help.hbs
@@ -15,6 +15,7 @@
         </ul>
         <ul class="usa-width-one-third mega__list">
           <li><a class="mega__page-link" href="{{transitionUrl}}/info/outreach.shtml">Trainings</a></li>
+          <li><a class="mega__page-link" href="/help-candidates-and-committees/question-rad">Submit a question to RAD</a></li>
         </ul>
       </div>
     </div>

--- a/scss/components/_contact-form.scss
+++ b/scss/components/_contact-form.scss
@@ -37,13 +37,6 @@
   }
 
   @include media($med) {
-    @include span-columns(9);
-    padding: u(4rem 0);
-
-    .contact-form__element {
-      @include span-columns(7 of 10);
-      @include shift(1);
-    }
 
     input,
     select {


### PR DESCRIPTION
This goes with https://github.com/18F/fec-cms/pull/1006

It removes the width restriction on the contact form, now that the entire thing is in a narrower container.

It also adds back the link to "Submit a question" in the Help nav, because with the CMS change, the page will work.

![image](https://cloud.githubusercontent.com/assets/1696495/25258469/a19033c4-260d-11e7-9b44-93015afddd61.png)
