### PR TITLE
Adding class for aligning post content to edge of icon

### DIFF
--- a/scss/components/_posts.scss
+++ b/scss/components/_posts.scss
@@ -64,6 +64,15 @@
   margin-left: u(3rem);
 }
 
+// If there's an icon in the title, use this class to align everything to the right of the icon
+.post--icon {
+  padding-left: u(3rem);
+
+  .icon {
+    margin-left: u(-3rem);
+  }
+}
+
 .post__pre {
   @include clearfix();
   color: $gray-dark;
@@ -117,13 +126,6 @@
 
   &:first-of-type {
     margin-top: u(.5rem);
-  }
-}
-
-@include media($lg) {
-  .post__path,
-  .post__preview {
-    padding-left: u(3rem);
   }
 }
 


### PR DESCRIPTION
Now, when a post title is long and breaks onto multiple lines, everything stays nice and aligned with the icon:

![image](https://cloud.githubusercontent.com/assets/1696495/25362877/6cce8a86-290b-11e7-90e5-75659e814bf0.png)

cc @jenniferthibault 