### PR TITLE
Update references to published style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We’re thrilled you want to get involved!
 
 ## Set up
 
-You can view the current styleguide on https://pages.18f.gov/fec-style/. It is
+You can view the current styleguide on https://fec-style.18f.gov/. It is
 updated automatically on every successful push to the `master` branch.
 
 


### PR DESCRIPTION
This changeset updates our 18F pages reference to the new home after the Federalist migration.