### PR TITLE
Setting href to void

### DIFF
--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -62,7 +62,7 @@ SiteNav.prototype.initMegaMenu = function() {
     $(this).append(submenu);
 
     // Remove hrefs and default click behavior for links that have submenus
-    $(this).find('.site-nav__link').attr('href', '').on('click', function(e) {
+    $(this).find('.site-nav__link').attr('href', 'javascript:void(0)').on('click', function(e) {
       e.preventDefault();
     });
   });

--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -62,7 +62,7 @@ SiteNav.prototype.initMegaMenu = function() {
     $(this).append(submenu);
 
     // Remove hrefs and default click behavior for links that have submenus
-    $(this).find('.site-nav__link').attr('href', 'javascript:void(0)').on('click', function(e) {
+    $(this).find('.site-nav__link').attr('href', '#0').on('click', function(e) {
       e.preventDefault();
     });
   });

--- a/tests/site-nav.js
+++ b/tests/site-nav.js
@@ -82,7 +82,7 @@ describe('SiteNav', function() {
       });
 
       it('should remove hrefs from links that have submenus', function() {
-        expect(this.siteNav.$menu.find('[data-submenu] a').attr('href')).to.equal('');
+        expect(this.siteNav.$menu.find('[data-submenu] a').attr('href')).to.equal('#0');
       });
     });
   });


### PR DESCRIPTION
This helps fix the broken mega menu links in Safari by setting the `href` of the links in the nav to `javascript:void(0)`. 