### PR TITLE
Line borders for flat lists

### DIFF
--- a/scss/components/_list-styles.scss
+++ b/scss/components/_list-styles.scss
@@ -78,6 +78,23 @@
   }
 }
 
+.list--flat-bordered {
+  @extend .list--flat;
+  padding-bottom: u(.5rem);
+
+  li {
+    &::after {
+      content: '|';
+      padding-left: u(1rem);
+    }
+
+    &:last-child::after {
+      content: '';
+      padding-left: 0;
+    }
+  }
+}
+
 .list--columns {
   @include media($med) {
     @include columns(2)


### PR DESCRIPTION
New class for line border separators for flat (inline) lists.
In support of: https://github.com/18F/fec-cms/pull/960