### PR TITLE
Agenda styles

### DIFF
--- a/scss/components/_agendas.scss
+++ b/scss/components/_agendas.scss
@@ -1,0 +1,53 @@
+.agenda {
+  counter-reset: agenda;
+
+  & > li {
+    margin-bottom: 4rem;
+    padding-left: 3rem;
+    position: relative;
+
+    &::before {
+      @include heading(h3);
+      position: absolute;
+      left: 0;
+      top: 0;
+      counter-increment: agenda;
+      content: counters(agenda,'') '.';
+    }
+  }
+
+  a[href$=".pdf"] {
+    margin-left: 6rem;
+
+    &::before {
+      @include u-icon($document, $base, 3rem, 3rem, 50%);
+      background-position: 0 50%;
+      content: '';
+      display: inline-block;
+      margin-left: -3rem;
+      vertical-align: middle;
+    }
+  }
+}
+
+.agenda__text {
+  margin-top: 2.6rem;
+
+}
+
+.agenda__heading {
+  margin-bottom: 2rem;
+}
+
+.pdf-link {
+  margin-left: 3rem;
+  
+  &::before {
+    @include u-icon($document, $base, 3rem, 3rem, 50%);
+    background-position: 0 50%;
+    content: '';
+    display: inline-block;
+    margin-left: -3rem;
+    vertical-align: middle;
+  }
+}

--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -5,6 +5,7 @@
 // Styleguide components
 
 @import 'accordions'; // @TODO: Add inverse accordion
+@import 'agendas';
 @import 'billboards';
 @import 'breakdowns';
 @import 'breadcrumbs'; // Document

--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -47,3 +47,8 @@ dl {
 li p:last-child {
   margin-bottom: 0;
 }
+
+p + ul,
+p + ol {
+  margin-top: u(-2rem);
+}

--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -51,7 +51,7 @@ h6 {
 p {
   color: inherit;
   font-size: u(1.6rem);
-  margin: u(0 0 2.6rem 0);
+  margin: u(0 0 2.4rem 0);
   max-width: u(80rem);
   width: 100%;
 


### PR DESCRIPTION
This adds styles for https://github.com/18F/fec-cms/pull/1060

It also makes two minor universal typographic changes that I worked out while pairing with @jenniferthibault . 

- Reduce space by 2px between paragraphs
- Reduce space between a `<p>` and a `<ul>` or `<ol>` 
