### PR TITLE
Remove beta from name/links, move to 'live' stage

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -20,7 +20,7 @@ parent: openFEC
 
 # Maturity stage of the project (required)
 # values: discovery, alpha, beta, live
-stage: beta
+stage: live
 
 # Should this repo have automated tests? If so, set to `true`. (required)
 # values: true, false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Federal Election Commission (FEC) releases information to the public about m
 
 Are you interested in seeing how much money a candidate raised? Or spent? How much debt they took on? Who contributed to their campaign? The FEC is the authoritative source for that information.
 
-betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users.
+FEC.gov is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users.
 
 ## FEC repositories
 We welcome you to explore, make suggestions, and contribute to our code.
@@ -15,11 +15,11 @@ We welcome you to explore, make suggestions, and contribute to our code.
 This repository, [fec-style](https://github.com/18F/fec-style), houses our shared styles and user interface components.
 
 ### All repositories
-- [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from betaFEC’s feedback widget here, and this is the best place to submit general feedback.
-- [openFEC](https://github.com/18F/openfec): betaFEC’s API
-- [openFEC-web-app](https://github.com/18f/openfec-web-app): the betaFEC web app for exploring campaign finance data
+- [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from the FEC’s feedback widget here, and this is the best place to submit general feedback.
+- [openFEC](https://github.com/18F/openfec): the FEC’s API
+- [openFEC-web-app](https://github.com/18f/openfec-web-app): the FEC web app for exploring campaign finance data
 - [fec-style](https://github.com/18F/fec-style): shared styles and user interface components
-- [fec-cms](https://github.com/18F/fec-cms): the content management system (CMS) for betaFEC
+- [fec-cms](https://github.com/18F/fec-cms): the content management system (CMS) for the FEC
 
 ## Get involved
 We’re thrilled you want to get involved!

--- a/fec-template/index.html
+++ b/fec-template/index.html
@@ -26,7 +26,7 @@
 <div class="kss-sidebar kss-style">
   <header class="kss-header">
     <span class="draft-note">Draft</span>
-    <h1 class="kss-doc-title"><em>beta</em>.FEC.gov style guide</h1>
+    <h1 class="kss-doc-title">FEC.gov style guide</h1>
   </header>
   <nav class="kss-nav">
     <ul class="kss-nav__menu">

--- a/fec-template/template_config.js
+++ b/fec-template/template_config.js
@@ -28,7 +28,7 @@ module.exports.options = {
   'title': {
     string: true,
     multiple: false,
-    describe: 'Styles for the new beta.fec.gov',
+    describe: 'Styles for the new FEC.gov',
     default: 'Style guide'
   }
 };

--- a/fec-template/templates/billboard.hbs
+++ b/fec-template/templates/billboard.hbs
@@ -4,7 +4,7 @@
   </div>
   <div class="billboard__content">
     <h2 class="feature__title">The FEC API: Use our data in your project</h2>
-    <p>An application programming interface (API)  is an easy way for computers, programs and developers to share and translate large amounts of data in meaningful ways. We recently released the FEC’s first API to help you use the data to tell your own story. This API is the backbone of the campaign finance data on beta.FEC.gov.</p>
+    <p>An application programming interface (API)  is an easy way for computers, programs and developers to share and translate large amounts of data in meaningful ways. We recently released the FEC’s first API to help you use the data to tell your own story. This API is the backbone of the campaign finance data on FEC.gov.</p>
     <p>Check out the <a href="https://api.open.fec.gov">API documentation</a>.</p>
   </div>
 </div>

--- a/scss/styleguide.md
+++ b/scss/styleguide.md
@@ -1,5 +1,5 @@
 # Getting started
 
-This is the collection of styles and design patterns that make up [beta.FEC.gov](https://beta.fec.gov/). Like the main site, the style guide is a work in progress. We don't yet have a full list of design patterns or complete documentation, but we're actively developing these resources as we build the site.
+This is the collection of styles and design patterns that make up [FEC.gov](https://www.fec.gov/). Like the main site, the style guide is a work in progress. We don't yet have a full list of design patterns or complete documentation, but we're actively developing these resources as we build the site.
 
 [Let us know](https://github.com/18f/fec-style/issues) how we can improve.


### PR DESCRIPTION
I removed the "beta" from the name "betaFEC", and changed "beta.fec.gov" to "www.fec.gov". I also moved the maturity stage of the application from `beta` to `live`.