### PR TITLE
Table style tweaks

### DIFF
--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -66,6 +66,7 @@
   height: 100%;
   font-family: $sans-serif;
   position: relative;
+  table-layout: auto;
 
   th {
     line-height: u(1.4rem);

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -341,7 +341,7 @@
   }
 
   .column--med {
-    width: 15%;
+    min-width: 180px;
   }
 
   .column--large {
@@ -361,11 +361,5 @@
     .column--med {
       width: 25%;
     }
-  }
-}
-
-@include media($lg) {
-  .column--med {
-    width: 12%;
   }
 }

--- a/scss/modules/_datatables.scss
+++ b/scss/modules/_datatables.scss
@@ -80,7 +80,7 @@
       background-position: calc(100% - 1rem) 50%;
       background-repeat: no-repeat;
       cursor: pointer;
-      padding-right: u(2rem);
+      padding-right: u(3rem);
     }
 
     &.sorting {


### PR DESCRIPTION
This makes datatables `table-layout: auto`, which works like magic, and sets min-width on `column--med` to support https://github.com/18F/openFEC-web-app/pull/2095