### PR TITLE
Typeahead fixes

### DIFF
--- a/js/filter-typeahead.js
+++ b/js/filter-typeahead.js
@@ -6,6 +6,7 @@ var $ = require('jquery');
 var URI = require('urijs');
 var _ = require('underscore');
 var typeahead = require('./typeahead');
+var helpers = require('./helpers');
 
 var ID_PATTERN = /^\w{9}$/;
 
@@ -34,7 +35,7 @@ function stripQuotes(value) {
 var textDataset = {
   display: 'id',
   source: function(query, syncResults) {
-    syncResults([{id: query}]);
+    syncResults([{id: helpers.sanitizeValue(query)}]);
   },
   templates: {
     suggestion: function(datum) {

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -4,6 +4,7 @@ var $ = require('jquery');
 var URI = require('urijs');
 var _ = require('underscore');
 var Handlebars = require('handlebars');
+var helpers = require('./helpers');
 
 // Hack: Append jQuery to `window` for use by typeahead.js
 window.$ = window.jQuery = $;
@@ -117,7 +118,7 @@ var individualDataset = {
   display: 'id',
   source: function(query, syncResults) {
     syncResults([{
-      id: query,
+      id: helpers.sanitizeValue(query),
       type: 'individual'
     }]);
   },
@@ -135,7 +136,7 @@ var siteDataset = {
   display: 'id',
   source: function(query, syncResults) {
     syncResults([{
-      id: query,
+      id: helpers.sanitizeValue(query),
       type: 'site'
     }]);
   },

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -80,7 +80,7 @@ var committeeEngine = createEngine({
 var candidateDataset = {
   name: 'candidate',
   display: 'name',
-  limit: 3,
+  limit: 5,
   source: candidateEngine,
   templates: {
     header: '<span class="tt-suggestion__header">Select a candidate:</span>',
@@ -98,7 +98,7 @@ var candidateDataset = {
 var committeeDataset = {
   name: 'committee',
   display: 'name',
-  limit: 3,
+  limit: 5,
   source: committeeEngine,
   templates: {
     header: '<span class="tt-suggestion__header">Select a committee:</span>',


### PR DESCRIPTION
This raises the limit on typeahead suggestions which fixes the issue where sometimes a longer query would result in missing matches, as was noted when search for Paul Ryan:

![image](https://cloud.githubusercontent.com/assets/1696495/26660146/d22186d6-462a-11e7-911f-23478f2b32f7.png)

It also uses the `sanitizeValue` helper to strip any unallowed characters from typeahead inputs, which prevents scripts from being inserted and executed.

Resolves https://github.com/18F/fec-style/issues/712
Resolves https://github.com/18F/fec-style/issues/714