### PR TITLE
Adding tag__category--and

### DIFF
--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -70,6 +70,17 @@
   }
 }
 
+.tag__category--and {
+  .tag__item {
+    margin-right: u(4rem);
+
+    &::after {
+      content: 'and';
+      right: u(-3.25rem);
+    }
+  }
+}
+
 .tag__category__range--amount,
 .tag__category__range--date {
   .tag__item {


### PR DESCRIPTION
Adds the ability to make a `tag__category` show `and` between tags:

![image](https://user-images.githubusercontent.com/1696495/26890561-c4966aea-4b66-11e7-9507-96d49bdef06d.png)

To implement, use `<li class="tag__category tag__category--and">`. (Note it's added to `.tag__category`.

cc @anthonygarvan 