### PR TITLE
Profile style adjustments

### DIFF
--- a/scss/components/_figures.scss
+++ b/scss/components/_figures.scss
@@ -57,6 +57,14 @@
     vertical-align: top;
   }
 
+  .simple-table {
+    margin-top: u(1rem);
+  }
+
+  .tag__category {
+    margin-top: 0;
+  }
+
   @include media($med) {
     padding: u(2rem 4rem);
   }

--- a/scss/components/_figures.scss
+++ b/scss/components/_figures.scss
@@ -44,6 +44,7 @@
   padding: u(1rem);
   margin-bottom: u(2rem);
   border-radius: 2px;
+  page-break-inside: avoid;
 
   .figure__label {
     font-weight: bold;
@@ -54,6 +55,10 @@
     font-size: u(1.6rem);
     padding: u(.5rem);
     vertical-align: top;
+  }
+
+  @include media($med) {
+    padding: u(2rem 4rem);
   }
 }
 

--- a/scss/components/_side-nav.scss
+++ b/scss/components/_side-nav.scss
@@ -64,7 +64,6 @@
 //
 
 .side-nav-alt {
-  display: table-cell;
   width: 100%;
 
   ul {
@@ -118,6 +117,7 @@
   }
 
   @include media($med) {
+    display: table-cell;
     width: 250px;
   }
 }

--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -139,6 +139,23 @@
   padding-left: u(2.5rem);
 }
 
+// Utility margin classes
+.u-margin--bottom {
+  margin-bottom: u(1rem);
+}
+
+.u-margin--top {
+  margin-top: u(1rem);
+}
+
+.u-margin--left {
+  margin-left: u(1rem);
+}
+
+.u-margin--right {
+  margin-right: u(1rem);
+}
+
 // horizontal rule
 
 .hr--lighter {

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -37,6 +37,10 @@
 
 .results-info--simple {
   border-top: none;
+
+  .button--export {
+    float: none;
+  }
 }
 
 .results-info--bottom {

--- a/scss/modules/_results-info.scss
+++ b/scss/modules/_results-info.scss
@@ -37,10 +37,6 @@
 
 .results-info--simple {
   border-top: none;
-
-  .button--export {
-    float: none;
-  }
 }
 
 .results-info--bottom {


### PR DESCRIPTION
- Fixes various small spacing issues on profile pages
- Adds utilities for adding 1rem of margin on any side
- Prevents page-breaking in the middle of financial summary tables when printing
- Makes the side nav on profile pages full-width on small screens:
![image](https://user-images.githubusercontent.com/1696495/26954569-8d75cff6-4c65-11e7-8294-78ee6c8f0306.png)
