### PR TITLE
Adding styles for nested lists

### DIFF
--- a/scss/components/_list-styles.scss
+++ b/scss/components/_list-styles.scss
@@ -29,6 +29,42 @@
       margin-bottom: u(1.5rem);
     }
   }
+
+  ul, ol {
+    margin-left: u(1.5rem);
+
+    li:last-of-type {
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  ul li {
+    list-style-type: circle;
+  }
+
+  ul ul li {
+    list-style-type: square;
+  }
+}
+
+.list--numbered {
+  ul {
+    margin-bottom: 0;
+    margin-left: u(1.5rem);
+
+    li {
+      list-style-type: circle;
+    }
+  }
+
+  ol li {
+    list-style-type: lower-alpha;
+
+    ol li {
+      list-style-type: lower-roman;
+    }
+  }
 }
 
 .list--bulleted {


### PR DESCRIPTION
Goes along with https://github.com/18F/fec-cms/pull/1105 for styling indented lists.

![image](https://user-images.githubusercontent.com/1696495/27060288-96e6da48-4f90-11e7-8d1f-f720c7490e32.png)

The only thing we're not able to do is to italicize the lower roman lists because you don't have that fine-grained control over the generated value of a list in HTML/CSS.

