### PR TITLE
Typeahead limit & filter retention

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -83,7 +83,6 @@ FilterSet.prototype.activateEfiling = function() {
   if (_.isEmpty(this.efilingFilters)) {
     var $filters = this.$body.find('.js-efiling-filters .js-filter');
     this.efilingFilters = this.activate($filters);
-
   }
 };
 
@@ -171,6 +170,11 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
     });
   }
 
+  // If there was a previous query, combine the two
+  if (this.previousQuery) {
+    query = _.extend({}, this.previousQuery, query);
+  }
+
   // Identify which set of filters to activate and store as this.filters
   this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
 
@@ -178,6 +182,7 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
     filter.fromQuery(query);
   });
 
+  this.previousQuery = query;
   this.firstLoad = false;
 };
 

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -73,16 +73,17 @@ FilterSet.prototype.activate = function($selector) {
 };
 
 FilterSet.prototype.activateProcessed = function() {
-  var $filters = this.$body.find('.js-processed-filters .js-filter');
   if (_.isEmpty(this.processedFilters)) {
+    var $filters = this.$body.find('.js-processed-filters .js-filter');
     this.processedFilters = this.activate($filters);
   }
 };
 
 FilterSet.prototype.activateEfiling = function() {
-  var $filters = this.$body.find('.js-efiling-filters .js-filter');
   if (_.isEmpty(this.efilingFilters)) {
+    var $filters = this.$body.find('.js-efiling-filters .js-filter');
     this.efilingFilters = this.activate($filters);
+
   }
 };
 
@@ -173,18 +174,10 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   // Identify which set of filters to activate and store as this.filters
   this.filters = dataType === 'efiling' ? this.efilingFilters : this.processedFilters;
 
-  // If there's a previous query, activate filters
-  // This way we don't activate the initial query when toggling data type for the first time
-  if (!this.firstLoad && this.previousQuery.data_type === dataType) {
-    var previousQuery = this.previousQuery || query;
+  _.each(this.filters, function(filter) {
+    filter.fromQuery(query);
+  });
 
-    _.each(this.filters, function(filter) {
-      filter.fromQuery(previousQuery);
-    });
-  }
-
-  // Store the query for future reference
-  this.previousQuery = query;
   this.firstLoad = false;
 };
 

--- a/js/typeahead.js
+++ b/js/typeahead.js
@@ -98,7 +98,7 @@ var candidateDataset = {
 var committeeDataset = {
   name: 'committee',
   display: 'name',
-  limit: 5,
+  limit: 10,
   source: committeeEngine,
   templates: {
     header: '<span class="tt-suggestion__header">Select a committee:</span>',

--- a/tests/filter-set.js
+++ b/tests/filter-set.js
@@ -96,9 +96,10 @@ describe('FilterSet', function() {
           '</div>' +
         '</div>' +
         '<div class="js-efiling-filters">' +
-          '<div class="js-filter" data-filter="text">' +
-            '<input name="name">' +
-            '<button></button>' +
+          '<div class="js-filter" data-filter="checkbox">' +
+            '<input name="cycle" type="checkbox" value="2012" />' +
+            '<input name="cycle" type="checkbox" value="2014" />' +
+            '<input name="cycle" type="checkbox" value="2016" />' +
           '</div>' +
         '</div>' +
         '</form>'
@@ -113,7 +114,7 @@ describe('FilterSet', function() {
 
     it('activates and stores the efiling filters', function() {
       this.filterSet.activateEfiling();
-      expect(Object.keys(this.filterSet.efilingFilters)).to.deep.equal(['name']);
+      expect(Object.keys(this.filterSet.efilingFilters)).to.deep.equal(['cycle']);
     });
 
     it('does not activate filters if it has efiling filters', function() {
@@ -129,20 +130,12 @@ describe('FilterSet', function() {
         .attr('aria-hidden')).to.equal('false');
     });
 
-    it('stores the current query after switching', function() {
-      window.history.replaceState({}, null, '?name=Noah');
+    it('loads the toggled filters with relevant query params', function() {
+      window.history.replaceState({}, null, '?cycle=2012');
+      this.filterSet.activateEfiling();
       this.filterSet.activateSwitchedFilters('efiling');
       expect(this.filterSet.firstLoad).to.be.false;
-      expect(this.filterSet.previousQuery).to.deep.equal({name: 'Noah'});
-      window.history.replaceState({}, null, null);
-    });
-
-    it('loads from the previous query after switching', function() {
-      this.filterSet.activateAll();
-      this.filterSet.firstLoad = false;
-      this.filterSet.previousQuery = {cycle: ['2012'], data_type: 'processed'};
-      this.filterSet.switchFilters('processed');
-      expect(this.filterSet.$body.find('.js-processed-filters input[value="2012"]').is(':checked')).to.be.true;
+      expect(this.filterSet.$body.find('.js-efiling-filters input[value="2012"]').is(':checked')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This addresses a couple unrelated issues.

## 1. Raw/processed filte retention
Now, when you toggle between processed and raw data, the filters that were on one will be carried over to the other. This means that when you go to filings, receipts or disbursements from a committee page and then toggle, the data will still be for that committee:

![demo](http://g.recordit.co/nGY9E26yR9.gif)

Resolves https://github.com/18F/openFEC-web-app/issues/2130

## 2. Typeahead fix
It increases the limit on typeahead results to 5 candidates and 10 committees max, which addresses the bug with certain committees not showing up.

![image](https://user-images.githubusercontent.com/1696495/27246133-6be330d2-52a4-11e7-81c6-e09ae48417d1.png)

Resolves https://github.com/18F/openFEC-web-app/issues/2131
