### PR TITLE
Control width of page-link blocks

### DIFF
--- a/scss/components/_options.scss
+++ b/scss/components/_options.scss
@@ -68,6 +68,21 @@
 @include media($lg) {
   .option__content {
     @include span-columns(6 of 9);
+
+    .block-page,
+    .block-disabled_page {
+      @include span-columns(3 of 6);
+
+      &:nth-child(odd) {
+        margin-right: 0;
+      }
+
+      a::after {
+        content: '»';
+        display: inline;
+        margin-left: 5px;
+      }
+    }
   }
 
   .option__aside {

--- a/scss/components/_richtext.scss
+++ b/scss/components/_richtext.scss
@@ -29,6 +29,7 @@
 
   td {
     @extend .simple-table__cell;
+    padding-right: u(1rem) !important;
   }
 
   img {


### PR DESCRIPTION
This sets a gutter on the page-link blocks used on the Help landing page:
![image](https://user-images.githubusercontent.com/1696495/27247293-02551006-52ac-11e7-81e8-f9ed9540ee74.png)

It also generates the arrow as CSS pseuod-content so that the line break doesn't happen before the arrow.

Resolves https://github.com/18F/fec-style/issues/729