### PR TITLE
Checkbox dropdown list spacing

### DIFF
--- a/scss/components/_components.scss
+++ b/scss/components/_components.scss
@@ -9,7 +9,6 @@
 @import 'buttons';
 @import 'callouts';
 @import 'cards';
-@import 'charts'; // REFACTOR
 @import 'contact-form';
 @import 'contact-items'; // REFACTOR: https://github.com/18F/fec-style/issues/295
 @import 'cycle-select';

--- a/scss/components/_dropdowns.scss
+++ b/scss/components/_dropdowns.scss
@@ -170,7 +170,7 @@
 }
 
 .dropdown__selected {
-  margin-bottom: u(.5rem);
+  margin: u(.5rem 0);
 
   li {
     @include animation(fadeIn .2s ease-in);


### PR DESCRIPTION
This gives a little space for checkbox dropdown lists, especially for the new receipt/disbursement type line number filters. Supports https://github.com/18F/openFEC-web-app/issues/2150

![screen shot 2017-06-23 at 10 27 19 am](https://user-images.githubusercontent.com/24054/27493585-01afe0ba-57ff-11e7-9b4c-072757c8d288.png)


Also removes the `_charts.scss` in the `_components.scss` file to avoid a compilation warning.