### PR TITLE
fix: load filters on first load for filter switches

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -160,15 +160,15 @@ FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   var query = helpers.sanitizeQueryParams(URI.parseQuery(window.location.search));
   // Clear filters if this isn't the first page load
   // Set forceRemove: true to clear date filters that are usually nonremovable
-  if (!this.firstLoad) {
-    this.$body.trigger('tag:removeAll', {forceRemove: true});
-    // Go through the current panel and set loaded-once on each input
-    // So that they don't show loading indicators
-    _.each(this.filters, function(filter) {
-      filter.loadedOnce = false;
-      filter.$elm.find('input').data('loaded-once', false);
-    });
-  }
+
+
+  this.$body.trigger('tag:removeAll', {forceRemove: true});
+  // Go through the current panel and set loaded-once on each input
+  // So that they don't show loading indicators
+  _.each(this.filters, function(filter) {
+    filter.loadedOnce = false;
+    filter.$elm.find('input').data('loaded-once', false);
+  });
 
   // If there was a previous query, combine the two
   if (this.previousQuery) {

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -158,10 +158,8 @@ FilterSet.prototype.switchFilters = function(dataType) {
 FilterSet.prototype.activateSwitchedFilters = function(dataType) {
   // Save the current query for later
   var query = helpers.sanitizeQueryParams(URI.parseQuery(window.location.search));
-  // Clear filters if this isn't the first page load
+
   // Set forceRemove: true to clear date filters that are usually nonremovable
-
-
   this.$body.trigger('tag:removeAll', {forceRemove: true});
   // Go through the current panel and set loaded-once on each input
   // So that they don't show loading indicators


### PR DESCRIPTION
Ok, I think this does it. In attempting to retain filters for switches in https://github.com/18F/fec-style/pull/736, filters should still be activated on first load.

Fixes tag retention on: https://github.com/18F/openFEC-web-app/issues/2155