### PR TITLE
responsive styles for dense-table-container class

### DIFF
--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -316,10 +316,24 @@ h3 + .simple-table {
 
 // Dense table
 // For tables with a lot of data that need to be condensed
+.dense-table-container {
+  box-shadow: -10px 0 20px -10px $gray-medium inset;
+  overflow-x: scroll;
+
+  @include media($lg) {
+    box-shadow: none;
+  }
+}
+
+.option__content .dense-table-container {
+  box-shadow: -10px 0 20px -10px $gray-medium inset;
+  overflow-x: scroll;
+}
+
 .dense-table {
-  table-layout: auto;
-  border-top: none;
   border-bottom-width: 0;
+  border-top: none !important;
+  table-layout: auto;
 
   td,
   th {
@@ -334,6 +348,7 @@ h3 + .simple-table {
 
   thead th {
     border-bottom: 1px solid $primary;
+    padding: u(.5rem);
   }
 
   tbody th {

--- a/scss/components/_table-styles.scss
+++ b/scss/components/_table-styles.scss
@@ -251,7 +251,7 @@ h3 + .simple-table {
   }
 }
 
-// For custom_table_block in streamfactory
+// For custom_table_block
 
 .custom-table {
   box-shadow: -10px 0 20px -10px $gray-medium inset;
@@ -330,6 +330,7 @@ h3 + .simple-table {
   overflow-x: scroll;
 }
 
+// scss-lint:disable ImportantRule
 .dense-table {
   border-bottom-width: 0;
   border-top: none !important;


### PR DESCRIPTION
To solve the responsive issues that arise when using the Contribution Limits Snippet (class="dense-table") in pages with left sidebar and related content on the right. (https://github.com/18F/fec-cms/issues/1093)

Horizontal scrolling and a drop-shadow for a visual cue are used whenever this table is included inside a a div of class="option__content" and also when on a small screen regardless of the container it is in.

Inside class="option__content":
![cont_limits_scrnsht_small](https://user-images.githubusercontent.com/5572856/28380765-84e9a920-6c86-11e7-87de-16df62d5a143.gif)
 
Inside any other container:
![cont_limits_scrnsht_large](https://user-images.githubusercontent.com/5572856/28380901-f35d59e2-6c86-11e7-8f96-1c9d20ae2592.gif)





## Screenshots

- _Update the styleguide documentation, include a screenshot if applicable._
- _Include a screenshot of the new/updated styles in context (“in the wild”)._


_cc @username_
