### PR TITLE
Default election cycle

### DIFF
--- a/js/election-filter.js
+++ b/js/election-filter.js
@@ -14,6 +14,7 @@ function ElectionFilter(elm) {
   this.duration = parseInt(this.$elm.data('duration'));
   this.cycleName = this.$elm.data('cycle-name');
   this.fullName = this.$elm.data('full-name');
+  this.defaultCycle = this.$elm.data('default-cycle');
 
   this.$election = this.$elm.find('.js-election');
   this.$cycles = this.$elm.find('.js-cycles');
@@ -31,7 +32,7 @@ ElectionFilter.prototype = Object.create(Filter.prototype);
 ElectionFilter.constructor = ElectionFilter;
 
 ElectionFilter.prototype.fromQuery = function(query) {
-  var election = query[this.name] || '2016';
+  var election = query[this.name] || this.defaultCycle;
   var cycle = query[this.cycleName] || election;
   var full = query[this.fullName] !== null ? query[this.fullName] : true;
   if (election) {

--- a/tests/election-filter.js
+++ b/tests/election-filter.js
@@ -25,7 +25,8 @@ describe('Election filter', function() {
         'data-name="election_year"' +
         'data-cycle-name="cycle"' +
         'data-full-name="election_full"' +
-        'data-duration="4">' +
+        'data-duration="4"' +
+        'data-default-cycle="2016">' +
         '<label class="label" for="election_year">Election cycle</label>' +
         '<select name="election_year" class="js-election">' +
             '<option value="2016">2016</option>' +
@@ -51,6 +52,7 @@ describe('Election filter', function() {
   it('sets its initial state', function() {
     expect(this.filter.name).to.equal('election_year');
     expect(this.filter.duration).to.equal(4);
+    expect(this.filter.defaultCycle).to.equal(2016);
     expect(this.filter.fields).to.deep.equal(['election_year', 'cycle', 'election_full']);
   });
 


### PR DESCRIPTION
This uses `data-default-cycle` on the election year filters to set a default cycle if none is provided in the URL.

Goes with https://github.com/18F/openFEC-web-app/pull/2229