### PR TITLE
Adding nav item for campaign guidance

### DIFF
--- a/js/templates/nav-help.hbs
+++ b/js/templates/nav-help.hbs
@@ -10,10 +10,11 @@
           <p><a href="{{cmsUrl}}/help-candidates-and-committees" class="button button--alt-primary">Get started &raquo;</a></p>
         </div>
         <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="{{cmsUrl}}/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
+          <li><a class="mega__page-link" href="{{cmsUrl}}/help-candidates-and-committees#campaign-guidance">Campaign guidance</a></li>
           <li><a class="mega__page-link" href="{{cmsUrl}}/help-candidates-and-committees/forms">Forms</a></li>
         </ul>
         <ul class="usa-width-one-third mega__list">
+          <li><a class="mega__page-link" href="{{cmsUrl}}/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
           <li><a class="mega__page-link" href="{{transitionUrl}}/info/outreach.shtml">Trainings</a></li>
         </ul>
       </div>


### PR DESCRIPTION
This adds the "Campaign guidance" nav item that's necessary to ship the home page changes:

![image](https://user-images.githubusercontent.com/1696495/28804203-930af376-7616-11e7-941c-c39579fda9fa.png)

This item takes you to this point on the page:
![image](https://user-images.githubusercontent.com/1696495/28804218-aecd9e24-7616-11e7-99ba-ecee4163bf98.png)
