### PR TITLE
Adding a generic date filter for validating periods of time

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -14,6 +14,7 @@ var DateFilter = require('./date-filter').DateFilter;
 var ElectionFilter = require('./election-filter').ElectionFilter;
 var ToggleFilter = require('./toggle-filter').ToggleFilter;
 var RangeFilter = require('./range-filter').RangeFilter;
+var ValidateDateFilter = require('./validate-date-filter').ValidateDateFilter;
 
 function FilterSet(elm) {
   this.$body = $(elm);
@@ -39,6 +40,7 @@ var filterMap = {
   'select': SelectFilter,
   'toggle': ToggleFilter,
   'range': RangeFilter,
+  'validate-date': ValidateDateFilter
 };
 
 FilterSet.prototype.buildFilter = function($elm) {

--- a/js/validate-date-filter.js
+++ b/js/validate-date-filter.js
@@ -1,0 +1,155 @@
+'use strict';
+
+var $ = require('jquery');
+var moment = require('moment');
+
+var Filter = require('./filter-base.js');
+
+require('jquery.inputmask');
+require('jquery.inputmask/dist/inputmask/inputmask.date.extensions.js');
+require('jquery.inputmask/dist/inputmask/inputmask.numeric.extensions.js');
+
+/**
+ * ValidateDateFilter
+ * @class
+ * Special date filter for the 6-year date range inputs that need to validate that
+ * the dates entered are within a period of time
+ */
+function ValidateDateFilter(elm) {
+  Filter.Filter.call(this, elm);
+  this.duration = this.$elm.data('duration');
+  this.$range = this.$elm.find('.js-date-range');
+  this.$minDate = this.$elm.find('.js-min-date');
+  this.$maxDate = this.$elm.find('.js-max-date');
+  this.$submit = this.$elm.find('button');
+
+  this.$minDate.inputmask('mm/dd/yyyy', {
+    oncomplete: this.validate.bind(this)
+  });
+  this.$maxDate.inputmask('mm/dd/yyyy', {
+    oncomplete: this.validate.bind(this)
+  });
+
+  this.$input.on('change', this.handleInputChange.bind(this));
+
+  this.fields = ['min_' + this.name, 'max_' + this.name];
+
+  $(document.body).on('tag:removeAll', this.handleRemoveAll.bind(this));
+}
+
+ValidateDateFilter.prototype = Object.create(Filter.Filter.prototype);
+ValidateDateFilter.constructor = ValidateDateFilter;
+
+ValidateDateFilter.prototype.handleInputChange = function(e) {
+  var $input = $(e.target);
+  var value = $input.val();
+  var loadedOnce = $input.data('loaded-once') || false;
+  var range = $input.data('range') || false;
+  var nonremovable = true;
+  var rangename = 'date';
+  var eventName;
+
+  if ($input.data('had-value') && value.length > 0) {
+    eventName = 'filter:renamed';
+  } else if (value.length > 0) {
+    eventName = 'filter:added';
+    $input.data('had-value', true);
+  } else {
+    eventName = 'filter:removed';
+    $input.data('had-value', false);
+  }
+
+  if (loadedOnce) {
+    this.$submit.addClass('is-loading');
+  }
+
+  $input.trigger(eventName, [
+    {
+      key: $input.attr('id'),
+      value: this.formatValue($input, value),
+      loadedOnce: loadedOnce,
+      range: range,
+      rangeName: rangename,
+      name: this.name,
+      nonremovable: nonremovable,
+      removeOnSwitch: true
+    }
+  ]);
+
+  if (eventName === 'filter:renamed') {
+    $input.data('loaded-once', true);
+  }
+};
+
+ValidateDateFilter.prototype.validate = function() {
+  var minDateYear = this.$minDate.val() ?
+    parseInt(this.$minDate.val().split('/')[2]) : this.minYear;
+  var maxDateYear = this.$maxDate.val() ?
+    parseInt(this.$maxDate.val().split('/')[2]) : this.maxYear;
+  var span = maxDateYear - minDateYear;
+  if ( span <= 5 ) {
+    this.hideWarning();
+    this.$elm.trigger('filters:validation', [
+      {
+        isValid: true,
+      }
+    ]);
+  } else {
+    this.showWarning();
+    this.$elm.trigger('filters:validation', [
+      {
+        isValid: false,
+      }
+    ]);
+  }
+};
+
+ValidateDateFilter.prototype.fromQuery = function(query) {
+  // If no values are passed in the query, then default to today - Jan 1 from 5 years ago.
+  var now = moment().format('MM/DD/YYYY');
+  var startYear = moment().format('YYYY') - this.duration + 1;
+  var defaultStart = moment('01/01/' + startYear, 'MM-DD-YYYY').format('MM/DD/YYYY');
+
+  var minDate = query['min_' + this.name] ? query['min_' + this.name] : defaultStart;
+  var maxDate = query['max_' + this.name] ? query['max_' + this.name] : now;
+  this.$minDate.val(minDate).change();
+  this.$maxDate.val(maxDate).change();
+  return this;
+};
+
+ValidateDateFilter.prototype.handleRemoveAll = function(e, opts) {
+  // If this is a forceRemove event that means it was triggered by table switch
+  // So we need to clear these inputs and set had-value to false so that it fires filter:added
+  var forceRemove = opts.forceRemove || false;
+
+  function remove($filter) {
+    $filter.val('');
+    $filter.data('had-value', false);
+    $filter.trigger('filter:removed', {loadedOnce: true});
+  }
+
+  if (forceRemove) {
+   remove(this.$minDate);
+   remove(this.$maxDate);
+  }
+};
+
+ValidateDateFilter.prototype.showWarning = function() {
+  if (!this.showingWarning) {
+    var warning =
+    '<div class="message message--error message--small">' +
+      'Please enter dates within six years of each other.' +
+    '</div>';
+    this.$range.after(warning);
+    this.showingWarning = true;
+  }
+};
+
+ValidateDateFilter.prototype.hideWarning = function() {
+  if (this.showingWarning) {
+    this.$elm.find('.message').remove();
+    this.showingWarning = false;
+  }
+};
+
+module.exports = {ValidateDateFilter: ValidateDateFilter};

--- a/js/validate-date-filter.js
+++ b/js/validate-date-filter.js
@@ -82,12 +82,10 @@ ValidateDateFilter.prototype.handleInputChange = function(e) {
 };
 
 ValidateDateFilter.prototype.validate = function() {
-  var minDateYear = this.$minDate.val() ?
-    parseInt(this.$minDate.val().split('/')[2]) : this.minYear;
-  var maxDateYear = this.$maxDate.val() ?
-    parseInt(this.$maxDate.val().split('/')[2]) : this.maxYear;
-  var span = maxDateYear - minDateYear;
-  if ( span <= 5 ) {
+  var minDate = moment(this.$minDate.val(), 'MM/DD/YYYY');
+  var maxDate = moment(this.$maxDate.val(), 'MM/DD/YYYY');
+  var span = maxDate.diff(minDate, 'years', true);
+  if ( span <= this.duration ) {
     this.hideWarning();
     this.$elm.trigger('filters:validation', [
       {

--- a/js/validate-date-filter.js
+++ b/js/validate-date-filter.js
@@ -137,7 +137,8 @@ ValidateDateFilter.prototype.handleRemoveAll = function(e, opts) {
 ValidateDateFilter.prototype.showWarning = function() {
   if (!this.showingWarning) {
     var warning =
-    '<div class="message message--error message--small">' +
+    '<div class="filter__message filter__message--error">' +
+      '<strong>Time period is too broad</strong><br>' +
       'Please enter dates within six years of each other.' +
     '</div>';
     this.$range.after(warning);
@@ -147,7 +148,7 @@ ValidateDateFilter.prototype.showWarning = function() {
 
 ValidateDateFilter.prototype.hideWarning = function() {
   if (this.showingWarning) {
-    this.$elm.find('.message').remove();
+    this.$elm.find('.filter__message').remove();
     this.showingWarning = false;
   }
 };

--- a/js/validate-date-filter.js
+++ b/js/validate-date-filter.js
@@ -105,9 +105,9 @@ ValidateDateFilter.prototype.validate = function() {
 };
 
 ValidateDateFilter.prototype.fromQuery = function(query) {
-  // If no values are passed in the query, then default to today - Jan 1 from 5 years ago.
+  // If no values are passed in the query, then default to today - Jan 1 from last year
   var now = moment().format('MM/DD/YYYY');
-  var startYear = moment().format('YYYY') - this.duration + 1;
+  var startYear = moment().format('YYYY') - 1;
   var defaultStart = moment('01/01/' + startYear, 'MM-DD-YYYY').format('MM/DD/YYYY');
 
   var minDate = query['min_' + this.name] ? query['min_' + this.name] : defaultStart;


### PR DESCRIPTION
This adds a new `ValidateDateFilter` class for use in https://github.com/18F/openFEC-web-app/pull/2213

It works by reading a `data-duration` attribute set on the element, and then as dates are entered, makes sure that they're within a 6 year window. 

![demo](http://g.recordit.co/hRmmWGEBYi.gif)

~I believe the logic is _not_ that the dates are within 6 years of each other but rather that the *years* of the dates are within six years. Is that right, @LindsayYoung ?~

cc @jenniferthibault and @jameshupp for help sorting out microcopy and interaction details. 
 
Update: per discussion with @LindsayYoung , the validation logic is based on the two dates being within 6 years of each other. I changed the functionality to validate using MomentJS's built in `diff` method.
