### PR TITLE
Fix filter loading state on pages with efiling filters

### DIFF
--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -76,6 +76,7 @@ FilterSet.prototype.activateProcessed = function() {
   if (_.isEmpty(this.processedFilters)) {
     var $filters = this.$body.find('.js-processed-filters .js-filter');
     this.processedFilters = this.activate($filters);
+    // Store the processed filters in this.filters for later reference
     this.filters = this.processedFilters;
   }
 };
@@ -84,6 +85,7 @@ FilterSet.prototype.activateEfiling = function() {
   if (_.isEmpty(this.efilingFilters)) {
     var $filters = this.$body.find('.js-efiling-filters .js-filter');
     this.efilingFilters = this.activate($filters);
+    // Store the efiling filters in this.filters for later reference
     this.filters = this.efilingFilters;
   }
 };

--- a/js/filter-set.js
+++ b/js/filter-set.js
@@ -76,6 +76,7 @@ FilterSet.prototype.activateProcessed = function() {
   if (_.isEmpty(this.processedFilters)) {
     var $filters = this.$body.find('.js-processed-filters .js-filter');
     this.processedFilters = this.activate($filters);
+    this.filters = this.processedFilters;
   }
 };
 
@@ -83,6 +84,7 @@ FilterSet.prototype.activateEfiling = function() {
   if (_.isEmpty(this.efilingFilters)) {
     var $filters = this.$body.find('.js-efiling-filters .js-filter');
     this.efilingFilters = this.activate($filters);
+    this.filters = this.efilingFilters;
   }
 };
 

--- a/tests/filter-set.js
+++ b/tests/filter-set.js
@@ -110,12 +110,15 @@ describe('FilterSet', function() {
     it('activates and stores processed filters', function() {
       this.filterSet.activateProcessed();
       expect(Object.keys(this.filterSet.processedFilters)).to.deep.equal(['name', 'cycle']);
+      expect(Object.keys(this.filterSet.filters)).to.deep.equal(['name', 'cycle']);
     });
 
     it('activates and stores the efiling filters', function() {
       this.filterSet.activateEfiling();
       expect(Object.keys(this.filterSet.efilingFilters)).to.deep.equal(['cycle']);
+      expect(Object.keys(this.filterSet.filters)).to.deep.equal(['cycle']);
     });
+
 
     it('does not activate filters if it has efiling filters', function() {
       this.filterSet.activateAll();


### PR DESCRIPTION
This fixes a bug where when you visit a page with both raw and processed filters, like fec.gov/data/filings , the filters all show a loading state initially. The bug was caused because when the table filter set is initially [activated for a given data type](https://github.com/18F/fec-style/blob/31ca6c3a060fbb47d9a3e10fcbaca20cc8133914/js/filter-set.js#L162) [we loop through](https://github.com/18F/fec-style/blob/31ca6c3a060fbb47d9a3e10fcbaca20cc8133914/js/filter-set.js#L171) `this.filters` to set `loadedOnce` to `false` for everyone. 

The problem was that `this.filters` was empty, because both the processed and efiling filters were stored in separate properties. Now, whichever one is active is stored in `this.filters`.