### PR TITLE
Moving accordion styles into common.scss

### DIFF
--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -26,6 +26,7 @@
 @import 'components/form-styles';
 
 // Universal components
+@import 'components/accordions';
 @import 'components/breadcrumbs';
 @import 'components/buttons';
 @import 'components/cards';

--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -4,7 +4,6 @@
 // Very common components
 @import 'components/search-controls';
 @import 'components/hero';
-@import 'components/accordions';
 @import 'components/callouts';
 @import 'components/contact-form';
 @import 'components/contact-items';


### PR DESCRIPTION
They're needed for the glossary on every page, so they should be in here.